### PR TITLE
Update Dockerfile to base FROM Centos node4 image

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/rhscl/nodejs-4-rhel7
+FROM centos/nodejs-4-centos7
 
 EXPOSE 8080
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.12-BUILD-NUMBER",
+  "version": "5.3.14-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.13-BUILD-NUMBER",
+  "version": "5.3.14-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.3.13
+sonar.projectVersion=5.3.14
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
Since Open sourcing this project we no longer want to inherit from RHEL image where user would need subscription in place to pull the Docker image.