### PR TITLE
Ensuring the export directory exists before exporting submissions

### DIFF
--- a/lib/routes/forms/submissions/handlers/exportCSVAsync.js
+++ b/lib/routes/forms/submissions/handlers/exportCSVAsync.js
@@ -7,6 +7,8 @@ var _ = require('underscore');
 var logger = require('../../../../util/logger').getLogger();
 var archiver = require('archiver');
 var storage = require('../../../../storage');
+var mkdirp = require('mkdirp');
+
 
 /**
  *
@@ -32,7 +34,8 @@ function registerExportedFileForDownload(connectionOptions, submissionZipFilePat
       //Finish, set the export status to complete and keep url.
       fhForms.core.updateCSVExportStatus(connectionOptions, {
         status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_COMPLETE,
-        message: "Exported submissions available to download <a id='submission_export_log_modal_download_link' href='" + submissionZipUrl.url + "'>here</a>"
+        message: "Exported submissions available to download <a id='submission_export_log_modal_download_link' href='" + submissionZipUrl.url + "'>here</a>",
+        downloadUrl: submissionZipUrl.url
       });
     });
   });
@@ -46,7 +49,8 @@ function registerExportedFileForDownload(connectionOptions, submissionZipFilePat
  */
 function cleanUpSubmissionFile(path, cb) {
   fs.stat(path, function(err, fileStats) {
-    if (err) {
+    //If the file does not exist, then there is no need to remove it.
+    if (err && err.code !== "ENOENT") {
       logger.warn({error: err}, "Error reading file " + path);
       return cb(err);
     }
@@ -88,10 +92,54 @@ function processExportResponse(params, exportedSubmissionCSVs) {
 
   var fileName = params.domain + "_" + params.environment + "_" + "submissioncsvexport.zip";
 
-  var exportedZipFilePath = path.join(fhConfig.value("fhmbaas.temp_forms_files_dest"), fileName);
+  var filesFolder = fhConfig.value("fhmbaas.temp_forms_files_dest");
+  var exportedZipFilePath = path.join(filesFolder, fileName);
 
-  cleanUpSubmissionFile(exportedZipFilePath, function(err) {
-    if (err && err.code !== "ENOENT") {
+  async.series([
+    //Ensuring that the export folder exists before attempting to create the zip file
+    function ensureExportFolderExists(cb) {
+      mkdirp(filesFolder, cb);
+    },
+    function cleanSubmissionExport(cb) {
+      cleanUpSubmissionFile(exportedZipFilePath, cb);
+    },
+    function sendZipFile() {
+      var zipFileStream = fs.createWriteStream(exportedZipFilePath);
+      var zip = archiver('zip');
+
+      zipFileStream.on('error', function(err) {
+        logger.error({error: err}, "Error zipping exported submissions");
+
+        fhForms.core.updateCSVExportStatus(params.connectionOptions, {
+          status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_ERROR,
+          message: "Error compressing exported submissions",
+          error: err
+        });
+      });
+
+      zipFileStream.on('close', function() {
+        logger.debug("Finished Export CSV Zip");
+
+        fhForms.core.updateCSVExportStatus(params.connectionOptions, {
+          status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_INPROGRESS,
+          message: "Finished compressing exported submissions. Registering the ZIP file for download."
+        });
+
+        registerExportedFileForDownload(params.connectionOptions, exportedZipFilePath);
+      });
+
+      zip.pipe(zipFileStream);
+
+      _.each(exportedSubmissionCSVs, function(csv, form) {
+        zip.append(csv, {name: form + '.csv'});
+      });
+
+      logger.debug("Finalising Export CSV Zip");
+
+      zip.finalize();
+    }
+  ], function(err) {
+    if (err) {
       fhForms.core.updateCSVExportStatus(params.connectionOptions, {
         status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_ERROR,
         message: "Error cleaning up submission file",
@@ -100,40 +148,6 @@ function processExportResponse(params, exportedSubmissionCSVs) {
 
       return;
     }
-
-    var zipFileStream = fs.createWriteStream(exportedZipFilePath);
-    var zip = archiver('zip');
-
-    zipFileStream.on('error', function(err) {
-      logger.error({error: err}, "Error zipping exported submissions");
-
-      fhForms.core.updateCSVExportStatus(params.connectionOptions, {
-        status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_ERROR,
-        message: "Error compressing exported submissions",
-        error: err
-      });
-    });
-
-    zipFileStream.on('close', function() {
-      logger.debug("Finished Export CSV Zip");
-
-      fhForms.core.updateCSVExportStatus(params.connectionOptions, {
-        status: fhForms.CONSTANTS.SUBMISSION_CSV_EXPORT.STATUS_INPROGRESS,
-        message: "Finished compressing exported submissions. Registering the ZIP file for download."
-      });
-
-      registerExportedFileForDownload(params.connectionOptions, exportedZipFilePath);
-    });
-
-    zip.pipe(zipFileStream);
-
-    _.each(exportedSubmissionCSVs, function(csv, form) {
-      zip.append(csv, {name: form + '.csv'});
-    });
-
-    logger.debug("Finalising Export CSV Zip");
-
-    zip.finalize();
   });
 }
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.19-BUILD-NUMBER",
+  "version": "5.3.20-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.19-BUILD-NUMBER",
+  "version": "5.3.20-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/test/unit/routes/submissions/handlers/test-exportCSVAsync.js
+++ b/test/unit/routes/submissions/handlers/test-exportCSVAsync.js
@@ -1,0 +1,202 @@
+var sinon = require('sinon');
+var proxyquire = require('proxyquire');
+var fhConfig = require('fh-config');
+var fixtures = require('../../../../fixtures');
+fhConfig.setRawConfig(fixtures.config);
+var logger = fhConfig.getLogger();
+var EventEmitter = require('events');
+
+describe("Submission Export CSV Async", function() {
+
+  beforeEach(function () {
+    var self = this;
+
+    //Generating mocks for Async CSV Export
+    this.generateMocks = function(options, assertAndDone) {
+      var mockCSVExportStatusInProgress = {
+        status: 'inprogress',
+        message: "Export In Progress"
+      };
+      var mockFilePath = "/path/to/export/dir";
+      var expectedFileName = "testdomain_testenvironment_submissioncsvexport.zip";
+      var expectedFullPath  = mockFilePath + "/" + expectedFileName;
+
+      var mockSubmissionCSVValues = {
+        'mockformid': "fieldtitle1,fieldtitle2\nvalue1,value2"
+      };
+
+      var mockFileDetails = {
+        _id: "mockfileid"
+      };
+
+      self.mockData = {
+        mockCSVExportStatusInProgress: mockCSVExportStatusInProgress,
+        mockFilePath: mockFilePath,
+        expectedFileName: expectedFileName,
+        mockSubmissionCSVValues: mockSubmissionCSVValues,
+        mockFileDetails: mockFileDetails,
+        expectedFullPath: expectedFullPath
+      };
+
+      var mockStartCSVExport = sinon.stub().callsArgWith(1, undefined, mockCSVExportStatusInProgress);
+      var mockExportSubmissions = sinon.stub().callsArgWith(2, undefined, mockSubmissionCSVValues);
+
+      var mockFhForms = {
+        core: {
+          startCSVExport: mockStartCSVExport,
+          exportSubmissions: mockExportSubmissions,
+          updateCSVExportStatus: sinon.spy()
+        }
+      };
+
+      var mockStorage = {
+        registerFile: sinon.stub().callsArgWith(1, undefined, mockFileDetails),
+        generateURL: assertAndDone
+      };
+
+      var mockFhConfig = {
+        '@global': true,
+        value: sinon.stub().returns(mockFilePath),
+        getLogger: sinon.stub().returns(logger)
+      };
+
+      var mockFileStream = new EventEmitter();
+
+      var mockArchiverZip = {
+        pipe: sinon.spy(),
+        append: sinon.spy(),
+        finalize: function() {
+          mockFileStream.emit('close');
+        }
+      };
+
+      var mockArchiver = sinon.stub().returns(mockArchiverZip);
+
+      var mockMkdirp = sinon.stub().callsArg(1);
+
+      var mockStat = sinon.stub().callsArgWith(1, options.fileError, options.fileResponse);
+
+      var mockFS = {
+        stat: mockStat,
+        unlink: sinon.stub().callsArg(1),
+        createWriteStream: sinon.stub().returns(mockFileStream)
+      };
+
+      var mockNext = sinon.spy();
+
+      var mockRequest = {
+        body: {},
+        connectionOptions: {
+          uri: 'mongodb://some.mongo.url'
+        },
+        params: {
+          domain: 'testdomain',
+          environment: 'testenvironment'
+        }
+      };
+
+      var mockResponse = {
+        json: sinon.spy()
+      };
+
+      self.mocks = {
+        'fh-forms': mockFhForms,
+        '../../../../storage': mockStorage,
+        'fh-config': mockFhConfig,
+        'archiver': mockArchiver,
+        'mkdirp': mockMkdirp,
+        'fs': mockFS
+      };
+
+      self.stubs = {
+        mockFileStream: mockFileStream,
+        mockStartCSVExport: mockStartCSVExport,
+        mockExportSubmissions: mockExportSubmissions,
+        mockFS: mockFS,
+        mockMkdirp: mockMkdirp,
+        mockArchiverZip: mockArchiverZip,
+        mockArchiver: mockArchiver,
+        mockNext: mockNext,
+        mockRequest: mockRequest,
+        mockResponse: mockResponse
+      };
+    }
+
+    this.assertThenDone = function(options, done) {
+
+     return function assertAndDone() {
+
+       //Expecting the CSV Start export process to be called
+       sinon.assert.calledOnce(self.stubs.mockStartCSVExport);
+       sinon.assert.calledWith(self.stubs.mockStartCSVExport, sinon.match(self.stubs.mockRequest.connectionOptions), sinon.match.func);
+
+       sinon.assert.calledOnce(self.stubs.mockExportSubmissions);
+       sinon.assert.calledWith(self.stubs.mockExportSubmissions, sinon.match({
+         asyncCSVExport: true,
+         uri: sinon.match(self.stubs.mockRequest.connectionOptions.uri)
+       }), sinon.match.object, sinon.match.func);
+
+       sinon.assert.calledOnce(self.stubs.mockMkdirp);
+       sinon.assert.calledWith(self.stubs.mockMkdirp, sinon.match(self.mockData.mockFilePath), sinon.match.func);
+
+       sinon.assert.calledOnce(self.stubs.mockFS.stat);
+       sinon.assert.calledWith(self.stubs.mockFS.stat, sinon.match(self.mockData.expectedFullPath), sinon.match.func);
+
+       if(options.expectFSUnlinkCalled) {
+         sinon.assert.calledOnce(self.stubs.mockFS.unlink);
+         sinon.assert.calledWith(self.stubs.mockFS.unlink, sinon.match(self.mockData.expectedFullPath), sinon.match.func);
+       } else {
+         sinon.assert.notCalled(self.stubs.mockFS.unlink);
+       }
+
+       sinon.assert.calledOnce(self.stubs.mockFS.createWriteStream);
+       sinon.assert.calledWith(self.stubs.mockFS.createWriteStream, sinon.match(self.mockData.expectedFullPath));
+
+       sinon.assert.calledOnce(self.stubs.mockArchiverZip.pipe);
+       sinon.assert.calledWith(self.stubs.mockArchiverZip.pipe, sinon.match(self.stubs.mockFileStream));
+
+       sinon.assert.calledOnce(self.stubs.mockArchiverZip.append);
+       sinon.assert.calledWith(self.stubs.mockArchiverZip.append, sinon.match(self.mockData.mockSubmissionCSVValues.mockformid), sinon.match({
+         name: sinon.match("mockformid.csv")
+       }));
+
+       sinon.assert.calledOnce(self.stubs.mockArchiver);
+
+       sinon.assert.notCalled(self.stubs.mockNext);
+
+       sinon.assert.calledOnce(self.stubs.mockResponse.json);
+       sinon.assert.calledWith(self.stubs.mockResponse.json, sinon.match(self.mockData.mockCSVExportStatusInProgress));
+       done();
+     }
+    }
+
+  });
+
+  it("Submission Export Should Ensure A File Exists", function(done) {
+    var self = this;
+
+    this.generateMocks({}, self.assertThenDone({}, done));
+
+    var exportCSVAsync = proxyquire('../../../../../lib/routes/forms/submissions/handlers/exportCSVAsync', this.mocks);
+
+    exportCSVAsync(self.stubs.mockRequest, self.stubs.mockResponse, self.stubs.mockNext);
+  });
+
+  it("Should Remove The File If It Exists", function(done) {
+    var self = this;
+
+    this.generateMocks({
+      fileResponse: {
+        path: "/path/to/file"
+      }
+    }, self.assertThenDone({
+      expectFSUnlinkCalled: true
+    }, done));
+
+    var exportCSVAsync = proxyquire('../../../../../lib/routes/forms/submissions/handlers/exportCSVAsync', this.mocks);
+
+    exportCSVAsync(self.stubs.mockRequest, self.stubs.mockResponse, self.stubs.mockNext);
+  });
+
+
+});


### PR DESCRIPTION
# Motivation

The CSV export process does not currently ensure that the export directory pointed to by the `fhmbaas.temp_forms_files_dest` config value exists.

This change ensures that the directory exists before trying to export submissions

# Changes

Updated lib/routes/forms/submissions/handlers/exportCSVAsync.js to use `mkdirp` to ensure the folder exists.