### PR TITLE
Ensuring full submission JSON object is used for notifying submission complete

### DIFF
--- a/lib/handlers/app/forms.js
+++ b/lib/handlers/app/forms.js
@@ -53,7 +53,7 @@ router.post('/submissions/:id/fields/:fieldid/files/:fileid/base64', fhForms.mid
 router.post('/submissions/:id/fields/:fieldid/files/:fileid', fhForms.middleware.submissions.getRequestFileParameters, fhForms.middleware.submissions.submitFormFile);
 
 //Verify Submission And Mark As Complete
-router.post('/submissions/:id/complete', fhForms.middleware.submissions.completeSubmission, fhmbaasMiddleware.appformsMiddleware.notifySubmissionComplete);
+router.post('/submissions/:id/complete', handlers.completeSubmission, fhmbaasMiddleware.appformsMiddleware.notifySubmissionComplete);
 
 //Get The Current Submission Status
 router.get('/submissions/:id/status', fhForms.middleware.submissions.status);

--- a/lib/handlers/app/handlers/completeSubmission.js
+++ b/lib/handlers/app/handlers/completeSubmission.js
@@ -1,0 +1,56 @@
+var async = require('async');
+var fhForms = require('fh-forms');
+var _ = require('underscore');
+var logger = require('../../../util/logger').getLogger();
+
+/**
+ *
+ * Handler for verifying and completing a form submission.
+ *
+ * Also notifies any subscribers to the form submission.
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+module.exports = function completeSubmission(req, res, next) {
+  var params = {
+    submission: {
+      submissionId: req.params.id
+    }
+  };
+
+  logger.debug("Middleware completeSubmission ", {params: params});
+
+  fhForms.core.completeFormSubmission(_.extend(params, req.connectionOptions), function(err, completionResult) {
+    if(err) {
+      logger.warn("Error Completing Submission", err);
+      return next(err);
+    }
+
+    //If the submission is still pending (e.g. there are missing files etc) then send the data back to the user.
+    if(completionResult.status === 'pending') {
+      return res.status(200).json(completionResult);
+    }
+
+    //Getting the data required for sending email
+    fhForms.core.getSubmissionEmailData(req.connectionOptions, {
+      _id: req.params.id
+    }, function(err, submissionEmailData) {
+      if (err) {
+        logger.warn("Error getting submission", err);
+        return next(err);
+      }
+
+      completionResult.formSubmission = submissionEmailData.formSubmission;
+      completionResult.notificationMessage = submissionEmailData.notificationMessage;
+
+      req.appformsResultPayload = {
+        data: completionResult
+      };
+
+      //Passsing control to the next middleware that is used for notifying subscribers to completed submissions
+      return next();
+    });
+  });
+};

--- a/lib/handlers/app/handlers/index.js
+++ b/lib/handlers/app/handlers/index.js
@@ -5,5 +5,6 @@
 
 module.exports = {
   generatePDF: require('./generatePDF'),
-  exportCSV: require('./generateCSV')
+  exportCSV: require('./generateCSV'),
+  completeSubmission: require('./completeSubmission')
 };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.20-BUILD-NUMBER",
+  "version": "5.3.21-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1690,8 +1690,8 @@
       }
     },
     "fh-forms": {
-      "version": "1.11.2",
-      "from": "fh-forms@1.11.2",
+      "version": "1.11.3",
+      "from": "fh-forms@1.11.3",
       "dependencies": {
         "async": {
           "version": "0.2.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.3.20-BUILD-NUMBER",
+  "version": "5.3.21-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fh-cluster": "0.3.0",
     "fh-component-metrics": "2.2.1",
     "fh-config": "1.0.3",
-    "fh-forms": "1.11.2",
+    "fh-forms": "1.11.3",
     "fh-health": "0.2.0",
     "fh-logger": "0.5.1",
     "fh-mbaas-middleware": "2.2.7",

--- a/test/stubs/fhForms/index.js
+++ b/test/stubs/fhForms/index.js
@@ -8,6 +8,42 @@ var noop = sinon.stub.yields();
 
 module.exports = {
   core: {
+    completeFormSubmission: function(expectedSubmissionStatus) {
+      var mockSubmission = fixtures.forms.submissions.get();
+      var stub = sinon.stub();
+
+      var mockSubmissionStatus = {
+        status: expectedSubmissionStatus
+      };
+
+
+      stub.withArgs(sinon.match({
+        uri: sinon.match(fixtures.mockMongoUrl),
+        submission: sinon.match({
+          submissionId: sinon.match(mockSubmission._id)
+        })
+      }), sinon.match.func).callsArgWith(1, undefined, mockSubmissionStatus);
+
+
+      stub.throws("Invalid Arguments");
+
+      return stub;
+    },
+    getSubmissionEmailData: function() {
+      var mockSubmission = fixtures.forms.submissions.get();
+      var stub = sinon.stub();
+
+      stub.withArgs(sinon.match({
+        uri: sinon.match(fixtures.mockMongoUrl)
+      }), sinon.match({
+        _id: sinon.match(mockSubmission._id)
+      }), sinon.match.func).callsArgWith(2, undefined, {
+        formSubmission: mockSubmission, notificationMessage: {submittedFields: []}});
+
+      stub.throws("Invalid Arguments");
+
+      return stub;
+    },
     exportSubmissions: function(expectedFileUrl){
       var stub = sinon.stub();
 
@@ -273,7 +309,7 @@ module.exports = {
       'processFileResponse': noop,
       'status': noop,
       'listProjectSubmissions': noop,
-      'get': noop,
+      'get': noop
     },
     'formProjects': {
       'getFormIds': noop,

--- a/test/unit/handlers/app/test_submission.js
+++ b/test/unit/handlers/app/test_submission.js
@@ -1,0 +1,115 @@
+var proxyquire = require('proxyquire');
+var fixtures = require('../../../fixtures');
+var stubs = require('../../../stubs');
+var sinon = require('sinon');
+var assert = require('assert');
+var fhConfig = require('fh-config');
+fhConfig.setRawConfig(fixtures.config);
+var logger = fhConfig.getLogger();
+
+describe("Complete Submission", function() {
+
+  beforeEach(function createRouter() {
+    var self = this;
+
+    self.createMocks = function(expectedSubmissionStatus) {
+      self.mockSubmission = fixtures.forms.submissions.get();
+
+      self.getSubmissionEmailDataStub = stubs.forms.core.getSubmissionEmailData();
+      self.completeFormSubmissionStub = stubs.forms.core.completeFormSubmission(expectedSubmissionStatus);
+
+      var mocks = {
+          '../../../util/logger': {
+            getLogger: sinon.stub().returns(logger)
+          },
+          'fh-forms': {
+            core: {
+              completeFormSubmission: self.completeFormSubmissionStub,
+              getSubmissionEmailData: self.getSubmissionEmailDataStub
+            }
+          }
+        };
+
+      self.appFormsHandler = proxyquire('../../../../lib/handlers/app/handlers/completeSubmission.js', mocks);
+    };
+  });
+
+  it("should get the submission result when it has completed", function(done) {
+    var self = this;
+    var expectedSubmissionStatus = 'complete';
+
+    self.createMocks(expectedSubmissionStatus);
+
+    var mockRequest = {
+      params: {
+        id: this.mockSubmission._id
+      },
+      connectionOptions: {
+        uri: fixtures.mockMongoUrl
+      }
+    };
+
+    var mockResponse = {
+      status: sinon.spy(),
+      json: sinon.spy()
+    };
+
+    this.appFormsHandler(mockRequest, mockResponse, function(err) {
+      assert.ok(!err, "Expected no error" + err);
+
+      sinon.assert.calledOnce(self.getSubmissionEmailDataStub);
+      sinon.assert.calledOnce(self.completeFormSubmissionStub);
+
+      //The request should not have been ended.
+      sinon.assert.notCalled(mockResponse.status);
+      sinon.assert.notCalled(mockResponse.json);
+
+      assert.equal(expectedSubmissionStatus, mockRequest.appformsResultPayload.data.status, "Expected the status of the submission completion to be complete");
+      assert.equal(self.mockSubmission._id, mockRequest.appformsResultPayload.data.formSubmission._id);
+
+      done();
+    })
+  });
+
+  it("should return the submission result if it is pending", function(done) {
+    var self = this;
+
+    var expectedSubmissionStatus = 'pending';
+
+    self.createMocks(expectedSubmissionStatus);
+
+    var mockRes = {
+      json: sinon.spy()
+    };
+
+    var nextSpy = sinon.spy();
+
+    var statusStub = sinon.stub().returns(mockRes);
+
+    var mockRequest = {
+      params: {
+        id: self.mockSubmission._id
+      },
+      connectionOptions: {
+        uri: fixtures.mockMongoUrl
+      }
+    };
+
+    var mockResponse = {
+      status: statusStub
+    };
+
+    this.appFormsHandler(mockRequest, mockResponse, nextSpy);
+
+    sinon.assert.calledOnce(statusStub);
+    sinon.assert.calledWith(statusStub, sinon.match(200));
+
+    sinon.assert.calledOnce(mockRes.json);
+    sinon.assert.calledWith(mockRes.json, sinon.match({status: expectedSubmissionStatus}));
+
+    sinon.assert.notCalled(nextSpy);
+
+    done();
+  });
+
+});


### PR DESCRIPTION
# Motivation

Notifications for completed submissions rely on the field data (e.g. field name, field code etc) being available to send the required email.

This change ensures that the full submission JSON is used when sending notification emails to the core platform.

# Changes

Switched to a `completeSubmission` handler that checks for submission completion and gets the full submission object before passing control to the `notifySubmissionComplete` express handler.