### PR TITLE
add timeout when call fh-ditch via http

### DIFF
--- a/lib/util/ditchhelper.js
+++ b/lib/util/ditchhelper.js
@@ -2,6 +2,8 @@ var request = require('request');
 var fhconfig = require('fh-config');
 var logger = require('../util/logger').getLogger();
 var url = require('url');
+const SHORT_TIMEOUT = 15000;
+const LONG_TIMEOUT = 60000;
 
 function getDitchUrl(path) {
   return url.format({
@@ -26,11 +28,15 @@ function doMigrate(domain, env, appName, securityToken, appGuid, coreHost, cb) {
       appName: appName,
       appGuid: appGuid,
       coreHost: coreHost
-    }
+    },
+    timeout: SHORT_TIMEOUT
   }, function(err, response, body) {
     if (err) {
       logger.error({error: err, body: body}, 'Got error when calling ditch migratedb endpoint');
       return cb(err, response);
+    } else if(response && response.statusCode !== 200){
+      logger.error({body: body}, 'none 200 status code received from fh-ditch for db migration');
+      return cb(new Error("received " + response.statusCode + " from fh-ditch"));
     } else {
       return cb(null, body);
     }
@@ -42,7 +48,8 @@ function checkStatus(cb) {
   request.get({
     url: url,
     json: true,
-    strictSSL: false
+    strictSSL: false,
+    timeout: SHORT_TIMEOUT
   }, function(err, response, body) {
     if (err) {
       return cb(err);
@@ -61,7 +68,8 @@ function removeAppCollection(appName, cb) {
     json: {
       appName: appName
     },
-    strictSSL: false
+    strictSSL: false,
+    timeout: LONG_TIMEOUT
   }, function(err, response, body) {
     if (err) {
       return cb(err);
@@ -83,7 +91,8 @@ function getAppInfo(appName, cb) {
       },
       qs: {
         app: appName
-      }
+      },
+      timeout: SHORT_TIMEOUT
     }, function(err, res, body) {
     if (err) {
       return cb(err);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.0-BUILD-NUMBER",
+  "version": "5.4.1-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.0-BUILD-NUMBER",
+  "version": "5.4.1-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.4.0
+sonar.projectVersion=5.4.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motive

At the moment, when fh-mbaas calls to fh-ditch to app db migration, there is no timeout value. Also fh-mbaas doesn't really check the status code from fh-ditch when invoke the app db migration. This could cause client to be stuck in the migration view.

## Changes

1. add time out value when fh-mbaas calls to fh-ditch. Those calls should be finished very quickly.
2. check the status code from fh-ditch when invoke the db migration and fail the request if fh-ditch return non 200 status code.

## JIRA

https://issues.jboss.org/browse/RHMAP-12103