### PR TITLE
Rhmap 12103

### DIFF
--- a/lib/middleware/mbaasApp.js
+++ b/lib/middleware/mbaasApp.js
@@ -133,11 +133,14 @@ function notifyAppDbMigration(action) {
     var dfutils = dfutils = require('../util/dfutils.js');
 
     dfutils.migrateAppDb(action, domain, env, name, function (err) {
-
       if (err) {
-        return next(new Error('Failed to set app to migrate ' + name, err));
+        // Don't abort the migration if the app state could not be set. If we do that the
+        // user would see an error even though the app has already been migrated. Just log
+        // the error and continue.
+        logger.error({err: err}, 'Failed to update app state for ' + name);
+      } else {
+        logger.info({ app: name }, 'App set to migrate');
       }
-      logger.info({ app: name }, 'App set to migrate');
       return next();
     });
   };

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.1-BUILD-NUMBER",
+  "version": "5.4.2-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.1-BUILD-NUMBER",
+  "version": "5.4.2-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.4.1
+sonar.projectVersion=5.4.2
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

The last step of the migration is calling fh-dynoman to update the app state to `MIGRATING`. When that step fails the user will see an error but the migration itself is already complete.

Why is updating the app state the last step in the migration process? Shoudln't it be one of the first? I assume it's ok because all the other operations are asynchronous jobs.

There are two options:

1) Try to update the app state early and abort the migration if that fails (and not leave the user with both an error and a migrated DB)

2) Ignore a potential error when updating the app state as the rest of the migration is already complete (this PR).

ping @wei-lee what do you think about that?