### PR TITLE
Added middleware to ensure that that the temporary files folder exists before parsing 

### DIFF
--- a/lib/handlers/app/forms.js
+++ b/lib/handlers/app/forms.js
@@ -4,16 +4,12 @@ var logger = require('../../util/logger').getLogger();
 var fhmbaasMiddleware = require('fh-mbaas-middleware');
 var handlers = require('./handlers');
 var fhConfig = require('fh-config');
-var multer = require('multer');
+var mkdirp = require('mkdirp');
+var getFileUploadMiddleware = require('../../middleware/getFileUploadMiddleware');
 
 var router = express.Router({
   mergeParams: true
 });
-
-//Multipart Form Request Parser
-router.use(multer({
-  dest: fhConfig.value("fhmbaas.temp_forms_files_dest")
-}));
 
 //Authentication for apps.
 router.use(fhmbaasMiddleware.auth.app);
@@ -47,10 +43,10 @@ router.get('/config', fhForms.middleware.formProjects.getConfig);
 
 //Submit A Base64 File To A Submission
 //This will decode the file to a binary string before streaming to the mongo database.
-router.post('/submissions/:id/fields/:fieldid/files/:fileid/base64', fhForms.middleware.submissions.getRequestFileParameters, fhForms.middleware.submissions.submitFormFileBase64);
+router.post('/submissions/:id/fields/:fieldid/files/:fileid/base64', getFileUploadMiddleware(), fhForms.middleware.submissions.getRequestFileParameters, fhForms.middleware.submissions.submitFormFileBase64);
 
 //Submit A File To A Submission
-router.post('/submissions/:id/fields/:fieldid/files/:fileid', fhForms.middleware.submissions.getRequestFileParameters, fhForms.middleware.submissions.submitFormFile);
+router.post('/submissions/:id/fields/:fieldid/files/:fileid', getFileUploadMiddleware(), fhForms.middleware.submissions.getRequestFileParameters, fhForms.middleware.submissions.submitFormFile);
 
 //Verify Submission And Mark As Complete
 router.post('/submissions/:id/complete', handlers.completeSubmission, fhmbaasMiddleware.appformsMiddleware.notifySubmissionComplete);

--- a/lib/middleware/getFileUploadMiddleware.js
+++ b/lib/middleware/getFileUploadMiddleware.js
@@ -1,0 +1,36 @@
+var mkdirp = require('mkdirp');
+var fhConfig = require('fh-config');
+var multer = require('multer');
+const TMP_FORMS_FILE_FOLDER_PATH = "fhmbaas.temp_forms_files_dest";
+var multerMiddleare;
+
+
+/**
+ *
+ * Middleware to ensure that the folder pointed to by fhmbaas.temp_forms_files_dest exists.
+ *
+ * The folder will be created if it does not already exist.
+ *
+ * @param req
+ * @param res
+ * @param next
+ */
+function ensureTmpFileFolderExists(req, res, next) {
+  //Ensuring that the folder for files exists before cacheing the file
+  mkdirp(fhConfig.value(TMP_FORMS_FILE_FOLDER_PATH), next);
+}
+
+/**
+ *
+ * Creating a middleware array to ensure that the temporary storage folder
+ * for files exists before attempting to parse the file with multer
+ *
+ * @returns {*[]}
+ */
+module.exports = function getFileUploadMiddleware() {
+  multerMiddleare = multerMiddleare || multer({
+    dest: fhConfig.value(TMP_FORMS_FILE_FOLDER_PATH)
+  });
+
+  return [ensureTmpFileFolderExists, multerMiddleare];
+};

--- a/lib/routes/forms/submissions/router.js
+++ b/lib/routes/forms/submissions/router.js
@@ -7,17 +7,12 @@ var fhConfig = require('fh-config');
 var handlers = require('./handlers');
 var CONSTANTS = require('../../../constants');
 var dataExport = require('./handlers/export');
-var multer = require('multer');
+var getFileUploadMiddleware = require('../../../middleware/getFileUploadMiddleware');
 
 module.exports = function() {
   var router = express.Router({
     mergeParams: true
   });
-
-  //Multipart Form Request Parser
-  router.use(multer({
-    dest: fhConfig.value("fhmbaas.temp_forms_files_dest")
-  }));
 
   //List Form Submissions (Paginated)
   router.get('/', paginate.middleware(fhConfig.value(CONSTANTS.CONFIG_PROPERTIES.PAGINATION_DEFAULT_LIMIT_KEY), fhConfig.value(CONSTANTS.CONFIG_PROPERTIES.PAGINATION_MAX_LIMIT_KEY)), handlers.list);
@@ -55,10 +50,10 @@ module.exports = function() {
   router.get('/:id', submissionsMiddleware.get);
 
   //Update A File For A Submission
-  router.post('/:id/fields/:fieldId/files/:fileId', submissionsMiddleware.getRequestFileParameters, submissionsMiddleware.addSubmissionFile);
+  router.post('/:id/fields/:fieldId/files/:fileId', getFileUploadMiddleware(), submissionsMiddleware.getRequestFileParameters, submissionsMiddleware.addSubmissionFile);
 
   //Update A File For A Submission
-  router.put('/:id/fields/:fieldId/files/:fileId', submissionsMiddleware.getRequestFileParameters, submissionsMiddleware.updateSubmissionFile);
+  router.put('/:id/fields/:fieldId/files/:fileId', getFileUploadMiddleware(), submissionsMiddleware.getRequestFileParameters, submissionsMiddleware.updateSubmissionFile);
 
   //Update A Single Submission
   router.put('/:id', submissionsMiddleware.update);

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.2-BUILD-NUMBER",
+  "version": "5.4.3-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.2-BUILD-NUMBER",
+  "version": "5.4.3-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.4.2
+sonar.projectVersion=5.4.3
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
# Motivation

There is no guarantee that the folder pointed to by `fhmbaas.temp_forms_files_dest` will exist when a file is being updated.

`multer` does not check this at file upload time and will throw an error if the folder does not exist.

To fix this, we need to check this before the `multer` middleware is executed.

# Changes

Moved the `multer` initialisation to a separate file and added the `ensureTmpFileFolderExists` middleware before the `multer` middleware to check that the folder exists.