### PR TITLE
Rhmap 15594

### DIFF
--- a/lib/util/ditchhelper.js
+++ b/lib/util/ditchhelper.js
@@ -29,7 +29,7 @@ function doMigrate(domain, env, appName, securityToken, appGuid, coreHost, cb) {
       appGuid: appGuid,
       coreHost: coreHost
     },
-    timeout: SHORT_TIMEOUT
+    timeout: LONG_TIMEOUT
   }, function(err, response, body) {
     if (err) {
       logger.error({error: err, body: body}, 'Got error when calling ditch migratedb endpoint');

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.4-BUILD-NUMBER",
+  "version": "5.4.5-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.4.4-BUILD-NUMBER",
+  "version": "5.4.5-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.4.4
+sonar.projectVersion=5.4.5
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
More customers ran into the problem where the database migration seemed to fail because the request from fh-mbaas to fh-ditch timed out. The `migratedb` endpoint in fh-ditch does not do very much, but there are two things that could lead to a timeout:

1) checking the availability of amqp by sending a ping to mbaas. There is a timeout (5 seconds) but the timeout only kicks in `after` the connection to amqp is established. If connecting to amqp takes a long time then this could be the reason for the timeout.

2) network problems

Since we don't have control over the state of the network the best option seems to be to use a longer timeout for the ditch request.

TODO: cherry pick into master