### PR TITLE
Use CentOS7 RPM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.vscode
 lib-cov/
 coverage/
 .project

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -13,7 +13,7 @@ RUN mkdir -p /var/feedhenry/data  && \
 
 # Installing fonts to be able to render PDFs for submissions
 RUN yum install -y dejavu-sans-fonts
-RUN yum install -y https://s3-eu-west-1.amazonaws.com/fhcap/phantomjs-1.9.7-3.el7map.x86_64.rpm
+RUN yum install -y http://cbs.centos.org/kojifiles/packages/phantomjs/1.9.7/3.el7/x86_64/phantomjs-1.9.7-3.el7.x86_64.rpm
 
 USER default
 


### PR DESCRIPTION
Using upstream CentOS7 RPM for PhantomJS

https://cbs.centos.org/koji/buildinfo?buildID=8186