### PR TITLE
add a route to receive migration status updates

### DIFF
--- a/lib/handlers/api.js
+++ b/lib/handlers/api.js
@@ -12,6 +12,7 @@ var eventMiddleware = require('../middleware/events');
 var appdataRouter = require('./app/data.js');
 var deleteEnvironmentData = require('../services/environment/deleteEnvironmentData.js');
 var logger = require('../util/logger.js').getLogger();
+var migrationStatusHandler = require('../messageHandlers/migrationStatusHandler');
 
 var router = new express.Router({
   mergeParams: true
@@ -34,6 +35,13 @@ router.post('/:domain/:environment/db', fhmbaasMiddleware.envMongoDb.getOrCreate
 
 router.post('/apps/:domain/:environment/:appname/migratedb', fhmbaasMiddleware.app.findOrCreateMbaasApp, middleware.createDbMiddleware, middleware.stopAppMiddleware, middleware.migrateDbMiddleware, middleware.notifyAppDbMigration('start'), function(req, res) {
   return res.json(req.createDbResult);
+});
+
+// This endpoint received the status updates about db migration and
+// forwards them to supercore
+router.post('/apps/migrationupdate', function (req, res) {
+  migrationStatusHandler.migrationUpdate(req.body);
+  return res.sendStatus(200);
 });
 
 //delete app databases associated with this domain and environment. Delete the environment datatabase and the environment db config

--- a/lib/messageHandlers/migrationStatusHandler.js
+++ b/lib/messageHandlers/migrationStatusHandler.js
@@ -122,6 +122,9 @@ function onPing(amqpConnection, exchangeName, json, headers, deliveryInfo) {
 }
 
 /**
+ * This whole function can be removed if we no longer use amqp for migration
+ * status updates.
+ *
  * Listen to amqp migration status updates and publish it to supercore.
  *
  * @param conf - main configuration that contains amqp url
@@ -140,8 +143,6 @@ function listenToMigrationStatus(amqpConnection, conf) {
       logger.debug("received dbMigrate message", {deliveryInfo: deliveryInfo});
       if (deliveryInfo.routingKey === 'fh.dbMigrate.ping') {
         onPing(amqpConnection, exchangeName, json, headers, deliveryInfo);
-      } else {
-        migrationUpdate(json);
       }
     }, function(err) {
       if (err) {
@@ -154,3 +155,4 @@ function listenToMigrationStatus(amqpConnection, conf) {
 }
 
 module.exports.listenToMigrationStatus = listenToMigrationStatus;
+module.exports.migrationUpdate = migrationUpdate;


### PR DESCRIPTION
DO NOT MERGE

part of a POC to prove that database migration status updates can be sent over http (instead of amqp).

adds a route to receive the status updates from fh-ditch over http and forwards them to supercore.