### PR TITLE
Rhmap 16211 - update component to use node 6

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,4 +1,4 @@
-FROM centos/nodejs-4-centos7:latest
+FROM centos/nodejs-6-centos7:latest
 
 EXPOSE 8080
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -3,7 +3,7 @@
 // https://github.com/feedhenry/fh-pipeline-library
 @Library('fh-pipeline-library') _
 
-fhBuildNode {
+fhBuildNode([labels: ['nodejs6-ubuntu']]) {
     stage('Install Dependencies') {
         npmInstall {}
         withPrivateNPMRegistry {

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM centos/nodejs-4-centos7:latest
+FROM centos/nodejs-6-centos7:latest
 
 EXPOSE 8080
 

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.8.1-BUILD-NUMBER",
+  "version": "5.9.0-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.8.1-BUILD-NUMBER",
+  "version": "5.9.0-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",
@@ -14,7 +14,7 @@
     "fh-mbaas": "./fh-mbaas.js"
   },
   "engines": {
-    "node": "4.4"
+    "node": "6.9"
   },
   "preferGlobal": true,
   "dependencies": {
@@ -57,17 +57,17 @@
     "underscore": "1.8.3"
   },
   "devDependencies": {
-    "grunt": "^1.0.1",
-    "grunt-fh-build": "^1.0.2",
+    "grunt": "~1.0.1",
+    "grunt-fh-build": "~2.0.0",
     "istanbul": "0.4.3",
-    "mocha": "^2.3.3",
+    "mocha": "~2.5.3",
     "mockgoose": "http://npm.skunkhenry.com/mockgoose/-/mockgoose-6.1.0.tgz",
-    "proxyquire": "^1.4.0",
+    "proxyquire": "~1.8.0",
     "should": "2.1.1",
     "sinon": "1.17.0",
     "supertest": "1.1.0",
     "turbo-test-runner": "http://npm.skunkhenry.com/turbo-test-runner/-/turbo-test-runner-0.6.3.tgz",
-    "deep-equal": "^1.0.1"
+    "deep-equal": "~1.0.1"
   },
   "repository": {
     "type": "git",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.8.1
+sonar.projectVersion=5.9.0
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
- Updated `engines` to `6.9` to `package.json`
- Updated version to use `~` from `^` in `package.json`
- Update grunt-fh-build
- Update Jenkinfiles for Wendy build
- Jira - https://issues.jboss.org/browse/RHMAP-16211 - https://issues.jboss.org/browse/RHMAP-16524