### PR TITLE
Rhmap 15809 - change log level to info when adding user to db

### DIFF
--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -35,7 +35,7 @@ function createDb(config, dbUser, dbUserPass, dbName, cb) {
         if (err) {
           return handleError(db, err, 'can not add user', cb);
         }
-        logger.trace({user: user, database: dbName}, 'mongo added new user');
+        logger.info({ user: user, database: dbName }, 'mongo added new user');
 
         db.close();
         return cb();

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.7.0-BUILD-NUMBER",
+  "version": "5.7.1-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.7.0-BUILD-NUMBER",
+  "version": "5.7.1-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.7.0
+sonar.projectVersion=5.7.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
## Motivation 
A customer could not upgrade their database due to the error "no users in migrated db".
This could not be reproduced.

## Result
Change log level to info when adding a user to the migration database so next time this occurs in production we can look at the logs.

## Jira
https://issues.jboss.org/browse/RHMAP-15809