### PR TITLE
Rhmap 17599

### DIFF
--- a/lib/util/dfutils.js
+++ b/lib/util/dfutils.js
@@ -67,7 +67,9 @@ function getDynoNameFromDynoFarm(domain, env, appname, cb) {
 function stopApp(domain, env, app, cb) {
   getDynoNameFromDynoFarm(domain, env, app, function(err, dynoName) {
     if (err) {
-      return cb(err);
+      // Can't get the dyno for an app so it's not deployed anywhere. In that case there
+      // is also no need to stop the app and we can just continue.
+      return cb();
     }
     var cmd = 'stop-app';
     dfc[cmd]([dynoName, app], function(err) {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.9.0-BUILD-NUMBER",
+  "version": "5.9.1-BUILD-NUMBER",
   "dependencies": {
     "archiver": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "5.9.0-BUILD-NUMBER",
+  "version": "5.9.1-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,6 +1,6 @@
 sonar.projectKey=fh-mbaas
 sonar.projectName=fh-mbaas-nightly-master
-sonar.projectVersion=5.9.0
+sonar.projectVersion=5.9.1
 
 sonar.sources=./lib
 sonar.tests=./test


### PR DESCRIPTION
When the dyno lookup for an app fails it is likely not deployed (and thus not running). No need to stop it in that case. We can just continue instead of throwing an error.