### PR TITLE
removed kernel headers dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,8 @@ RUN mkdir -p /var/feedhenry/data  && \
     chmod -R 755 /var/feedhenry && \
     ln -sf /usr/share/zoneinfo/UTC /etc/localtime && \
     mkdir -p config && \
-    chown -R default:root ./
+    chown -R default:root ./ && \
+    yum -y remove kernel-headers 
 
 # Installing fonts to be able to render PDFs for submissions
 RUN yum install -y dejavu-sans-fonts


### PR DESCRIPTION
https://issues.jboss.org/browse/RHMAP-17576

Verification:  Run the docker container locally and bash into it.  ```docker run -it IMAGE_NAME /bin/bash```
In the container run ``` yum list installed "kernel*"```
Ensure that no package is listed with kernel in it