### PR TITLE
⬆ Upgrade to fh-mbaas-middleware@2.3.2

### DIFF
--- a/licenses/HAWK_BSD-3-CLAUSE.TXT
+++ b/licenses/HAWK_BSD-3-CLAUSE.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014, Eran Hammer and other contributors.
+Copyright (c) 2012-2017, Eran Hammer and Project contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,4 +26,3 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                                   *   *   *
 
 The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
-

--- a/licenses/LODASH_MIT.TXT
+++ b/licenses/LODASH_MIT.TXT
@@ -1,25 +1,27 @@
-Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.5.2, copyright 2009-2013 Jeremy Ashkenas,
+The MIT License (MIT)
+
+Copyright 2012-2016 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js, copyright 2009-2016 Jeremy Ashkenas,
 DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
 
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.ENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+HALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/TYPE-IS_MIT.TXT
+++ b/licenses/TYPE-IS_MIT.TXT
@@ -1,23 +1,23 @@
-The MIT License (MIT)
+(The MIT License)
 
-Copyright (c) 2014 Jonathan Ong me@jongleberry.com
+Copyright (c) 2014 Jonathan Ong <me@jongleberry.com>
+Copyright (c) 2014-2015 Douglas Christopher Wilson <doug@somethingdoug.com>
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-ONNECTION WITH THE
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
 SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -1171,7 +1171,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-mbaas</td>
-<td>6.0.2-BUILD-NUMBER</td>
+<td>6.0.3-BUILD-NUMBER</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS_APACHE-2.0.TXT>FH-MBAAS_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1185,7 +1185,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-mbaas-middleware</td>
-<td>2.3.1</td>
+<td>2.3.2</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS-MIDDLEWARE_APACHE-2.0.TXT>FH-MBAAS-MIDDLEWARE_APACHE-2.0.TXT</a></td>
 </tr>

--- a/licenses/licenses.xml
+++ b/licenses/licenses.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <licenseSummary>
     <project>fh-mbaas</project>
-    <version>6.0.2-BUILD-NUMBER</version>
+    <version>6.0.3-BUILD-NUMBER</version>
     <license>Apache-2.0</license>
     <dependencies>
         <dependency>
@@ -1660,7 +1660,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas-middleware</packageName>
-            <version>2.3.1</version>
+            <version>2.3.2</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1670,7 +1670,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas</packageName>
-            <version>6.0.2-BUILD-NUMBER</version>
+            <version>6.0.3-BUILD-NUMBER</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.2-BUILD-NUMBER",
+  "version": "6.0.3-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",
@@ -325,8 +325,7 @@
     "decamelize": {
       "version": "1.2.0",
       "from": "decamelize@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
-      "optional": true
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-is": {
       "version": "0.1.3",
@@ -1953,7 +1952,7 @@
             "node-uuid": {
               "version": "1.4.7",
               "from": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             }
           }
         },
@@ -2249,9 +2248,9 @@
       }
     },
     "fh-mbaas-middleware": {
-      "version": "2.3.1",
-      "from": "fh-mbaas-middleware@2.3.1",
-      "resolved": "https://registry.npmjs.org/fh-mbaas-middleware/-/fh-mbaas-middleware-2.3.1.tgz",
+      "version": "2.3.2",
+      "from": "fh-mbaas-middleware@2.3.2",
+      "resolved": "https://registry.npmjs.org/fh-mbaas-middleware/-/fh-mbaas-middleware-2.3.2.tgz",
       "dependencies": {
         "accepts": {
           "version": "1.3.4",
@@ -2527,7 +2526,7 @@
             "node-uuid": {
               "version": "1.4.7",
               "from": "node-uuid@>=1.4.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
             },
             "rc": {
               "version": "0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.2-BUILD-NUMBER",
+  "version": "6.0.3-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",
@@ -37,7 +37,7 @@
     "fh-forms": "1.16.6",
     "fh-health": "0.3.2",
     "fh-logger": "0.5.1",
-    "fh-mbaas-middleware": "2.3.1",
+    "fh-mbaas-middleware": "2.3.2",
     "fh-messaging-client": "1.0.4",
     "fh-metrics-client": "1.0.5",
     "fh-service-auth": "1.0.4",


### PR DESCRIPTION
There aren't any functional changes in this patch to
fh-mbaas-middleware, it's just a fix to the way some of the
dependencies were specified so that it works better with npm 3 in
productization.

Since this also needs to go to FH-v4.6, and both master and FH-v4.6 are at the same commit, I won't open a separate PR for that -- once this gets merged I'll just fast-forward FH-v4.6 to match (at least I think I'll be able to do that).