### PR TITLE
fix(MongoDB issues): Upgrade mogodb deps

### DIFF
--- a/licenses/ASYNC_MIT.TXT
+++ b/licenses/ASYNC_MIT.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2018 Caolan McMahon
+Copyright (c) 2010-2014 Caolan McMahon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenses/HAWK_BSD-3-CLAUSE.TXT
+++ b/licenses/HAWK_BSD-3-CLAUSE.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2012-2014, Eran Hammer and other contributors.
+Copyright (c) 2012-2017, Eran Hammer and Project contributors
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
@@ -26,4 +26,3 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
                                   *   *   *
 
 The complete list of contributors can be found at: https://github.com/hueniverse/hawk/graphs/contributors
-

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -345,7 +345,7 @@
 <tr>
 <td>N/A</td>
 <td>boom</td>
-<td>5.2.0</td>
+<td>4.3.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=BOOM_BSD-3-CLAUSE.TXT>BOOM_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -359,7 +359,7 @@
 <tr>
 <td>N/A</td>
 <td>boom</td>
-<td>4.3.1</td>
+<td>5.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=BOOM_BSD-3-CLAUSE.TXT>BOOM_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -394,16 +394,23 @@
 <tr>
 <td>N/A</td>
 <td>bson</td>
-<td>0.4.23</td>
+<td>0.2.2</td>
+<td>UNKNOWN, UNKNOWN</td>
+<td><a href=#>No local license could be found for the dependency</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>bson</td>
+<td>1.0.9</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=BSON_APACHE-2.0.TXT>BSON_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>bson</td>
-<td>0.2.2</td>
-<td>UNKNOWN, UNKNOWN</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
+<td>0.4.23</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=BSON_APACHE-2.0.TXT>BSON_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -2200,6 +2207,20 @@
 <tr>
 <td>N/A</td>
 <td>mime-db</td>
+<td>1.24.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
+<td>1.30.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
 <td>1.12.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
@@ -2214,23 +2235,23 @@
 <tr>
 <td>N/A</td>
 <td>mime-db</td>
-<td>1.30.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-db</td>
 <td>1.33.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
-<td>mime-db</td>
-<td>1.24.0</td>
+<td>mime-types</td>
+<td>2.1.18</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-types</td>
+<td>2.1.17</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -2250,20 +2271,6 @@
 <td>N/A</td>
 <td>mime-types</td>
 <td>2.1.14</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-types</td>
-<td>2.1.17</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-types</td>
-<td>2.1.18</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
@@ -2305,14 +2312,14 @@
 <tr>
 <td>N/A</td>
 <td>mkdirp</td>
-<td>0.3.5</td>
+<td>0.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MKDIRP_MIT.TXT>MKDIRP_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mkdirp</td>
-<td>0.5.1</td>
+<td>0.3.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MKDIRP_MIT.TXT>MKDIRP_MIT.TXT</a></td>
 </tr>
@@ -2402,8 +2409,22 @@
 </tr>
 <tr>
 <td>N/A</td>
+<td>mongodb</td>
+<td>2.2.35</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=MONGODB_APACHE-2.0.TXT>MONGODB_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>mongodb-core</td>
 <td>1.3.18</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mongodb-core</td>
+<td>2.1.19</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
 </tr>
@@ -2494,14 +2515,14 @@
 <tr>
 <td>N/A</td>
 <td>mpromise</td>
-<td>0.5.5</td>
+<td>0.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MPROMISE_MIT.TXT>MPROMISE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mpromise</td>
-<td>0.2.1</td>
+<td>0.5.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MPROMISE_MIT.TXT>MPROMISE_MIT.TXT</a></td>
 </tr>
@@ -2557,14 +2578,14 @@
 <tr>
 <td>N/A</td>
 <td>nan</td>
-<td>2.4.0</td>
+<td>2.10.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>nan</td>
-<td>2.10.0</td>
+<td>2.7.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
 </tr>
@@ -2578,7 +2599,7 @@
 <tr>
 <td>N/A</td>
 <td>nan</td>
-<td>2.7.0</td>
+<td>2.4.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
 </tr>
@@ -2606,14 +2627,14 @@
 <tr>
 <td>N/A</td>
 <td>node-uuid</td>
-<td>1.4.8</td>
+<td>1.4.7</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NODE-UUID_MIT.TXT>NODE-UUID_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>node-uuid</td>
-<td>1.4.7</td>
+<td>1.4.8</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NODE-UUID_MIT.TXT>NODE-UUID_MIT.TXT</a></td>
 </tr>
@@ -2914,14 +2935,14 @@
 <tr>
 <td>N/A</td>
 <td>proxy-addr</td>
-<td>2.0.2</td>
+<td>2.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=PROXY-ADDR_MIT.TXT>PROXY-ADDR_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>proxy-addr</td>
-<td>2.0.3</td>
+<td>2.0.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=PROXY-ADDR_MIT.TXT>PROXY-ADDR_MIT.TXT</a></td>
 </tr>
@@ -2949,6 +2970,13 @@
 <tr>
 <td>N/A</td>
 <td>qs</td>
+<td>6.4.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>qs</td>
 <td>6.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
@@ -2959,13 +2987,6 @@
 <td>1.2.2</td>
 <td>UNKNOWN</td>
 <td><a href=QS_BSD.TXT>QS_BSD.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>qs</td>
-<td>6.4.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -2998,16 +3019,16 @@
 <tr>
 <td>N/A</td>
 <td>rc</td>
-<td>0.1.1</td>
+<td>0.4.0</td>
 <td>UNKNOWN</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
+<td><a href=RC_BSD%2CMIT%2CAPACHE2.TXT>RC_BSD,MIT,APACHE2.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>rc</td>
-<td>0.4.0</td>
+<td>0.1.1</td>
 <td>UNKNOWN</td>
-<td><a href=RC_BSD%2CMIT%2CAPACHE2.TXT>RC_BSD,MIT,APACHE2.TXT</a></td>
+<td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3026,14 +3047,14 @@
 <tr>
 <td>N/A</td>
 <td>readable-stream</td>
-<td>1.0.31</td>
+<td>1.0.34</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>readable-stream</td>
-<td>1.0.34</td>
+<td>1.1.14</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
 </tr>
@@ -3061,7 +3082,7 @@
 <tr>
 <td>N/A</td>
 <td>readable-stream</td>
-<td>1.1.14</td>
+<td>1.0.31</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
 </tr>
@@ -3110,14 +3131,14 @@
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.83.0</td>
+<td>2.78.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.78.0</td>
+<td>2.83.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
@@ -3320,15 +3341,15 @@
 <tr>
 <td>N/A</td>
 <td>shimmer</td>
-<td>1.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td>1.0.0</td>
+<td>UNKNOWN</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>shimmer</td>
-<td>1.0.0</td>
-<td>UNKNOWN</td>
+<td>1.2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
@@ -3341,13 +3362,6 @@
 <tr>
 <td>N/A</td>
 <td>sliced</td>
-<td>0.0.5</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>sliced</td>
 <td>1.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
@@ -3356,6 +3370,13 @@
 <td>N/A</td>
 <td>sliced</td>
 <td>0.0.4</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>sliced</td>
+<td>0.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
 </tr>
@@ -3509,14 +3530,14 @@
 <tr>
 <td>N/A</td>
 <td>statuses</td>
-<td>1.3.1</td>
+<td>1.5.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STATUSES_MIT.TXT>STATUSES_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>statuses</td>
-<td>1.5.0</td>
+<td>1.3.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STATUSES_MIT.TXT>STATUSES_MIT.TXT</a></td>
 </tr>
@@ -3530,14 +3551,14 @@
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>0.10.31</td>
+<td>1.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>1.1.1</td>
+<td>0.10.31</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>

--- a/licenses/licenses.xml
+++ b/licenses/licenses.xml
@@ -569,6 +569,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>bson</packageName>
+            <version>1.0.9</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>buffer-alloc-unsafe</packageName>
             <version>1.1.0</version>
             <licenses>
@@ -3399,6 +3409,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>mongodb-core</packageName>
+            <version>2.1.19</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>mongodb-uri</packageName>
             <version>0.9.7</version>
             <licenses>
@@ -3441,6 +3461,16 @@
         <dependency>
             <packageName>mongodb</packageName>
             <version>2.2.31</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>mongodb</packageName>
+            <version>2.2.35</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1387,6 +1387,11 @@
             }
           }
         },
+        "isarray": {
+          "version": "0.0.1",
+          "from": "isarray@0.0.1",
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        },
         "lodash": {
           "version": "2.2.1",
           "from": "lodash@2.2.1",
@@ -1396,6 +1401,26 @@
           "version": "2.19.3",
           "from": "moment@2.19.3",
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz"
+        },
+        "mongodb": {
+          "version": "2.1.18",
+          "from": "mongodb@2.1.18",
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz"
+        },
+        "mongodb-core": {
+          "version": "1.3.18",
+          "from": "mongodb-core@1.3.18",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz"
+        },
+        "readable-stream": {
+          "version": "1.0.31",
+          "from": "readable-stream@1.0.31",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "from": "string_decoder@>=0.10.0 <0.11.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
         },
         "underscore": {
           "version": "1.8.0",
@@ -4915,29 +4940,39 @@
       "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz"
     },
     "mongodb": {
-      "version": "2.1.18",
-      "from": "mongodb@2.1.18",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+      "version": "2.2.35",
+      "from": "mongodb@2.2.35",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
       "dependencies": {
-        "isarray": {
-          "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+        "bson": {
+          "version": "1.0.9",
+          "from": "bson@>=1.0.4 <1.1.0",
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz"
+        },
+        "es6-promise": {
+          "version": "3.2.1",
+          "from": "es6-promise@3.2.1",
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
         },
         "mongodb-core": {
-          "version": "1.3.18",
-          "from": "mongodb-core@1.3.18",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz"
+          "version": "2.1.19",
+          "from": "mongodb-core@2.1.19",
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz"
+        },
+        "process-nextick-args": {
+          "version": "1.0.7",
+          "from": "process-nextick-args@>=1.0.6 <1.1.0",
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
         },
         "readable-stream": {
-          "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+          "version": "2.2.7",
+          "from": "readable-stream@2.2.7",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz"
         },
         "string_decoder": {
-          "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "version": "1.0.3",
+          "from": "string_decoder@>=1.0.0 <1.1.0",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
         }
       }
     },

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.5-BUILD-NUMBER",
+  "version": "6.0.6-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "fh-metrics-client": "1.0.5",
     "fh-service-auth": "1.0.4",
     "mkdirp": "0.5.1",
-    "mongodb": "2.1.18",
+    "mongodb": "2.2.35",
     "mongodb-uri": "0.9.7",
     "mongoose": "4.11.14",
     "mongoose-timestamp": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.5-BUILD-NUMBER",
+  "version": "6.0.6-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20420

# What
Upgrade the mongodb version from `2.1.18` to `2.35.0`

# Why
Shows that this this issue in the authentication method was introduced in the version `2.1.16` and then was fixed in the version`2.2.33`. See more [here](https://jira.mongodb.org/browse/NODE-1161). Also, the previous version used of this lib in this project is deprecated. 

``` 
deprecated mongodb@2.1.18: Please upgrade to 2.2.19 or higher
``` 

# How
Via ` npm install --save --save-exact mongodb@2.2.35`

# Verification Steps
- No break changes in this update
- Check if the CI/Tests finish with success

## Checklist:

- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 