### PR TITLE
Upgrade dev dependencies 

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,21 +2,14 @@ module.exports = function(grunt) {
   'use strict';
 
   grunt.initConfig({
-
     _test_runner: '_mocha',
-
     _unit_args: '-b -A -u exports -t 20000',
-    optional: ['mocha -A -u exports --recursive -t 10000 test/accept/test-backoff.js'],
-
-    unit: ['echo $NODE_PATH', '<%= _test_runner %> <%= _unit_args %> --recursive ./test/unit/**/test*.js'],
-
+    optional: ['<%= _test_runner %> --recursive test/accept/test-backoff.js --exit'],
+    unit: ['echo $NODE_PATH', '<%= _test_runner %> <%= _unit_args %> --recursive ./test/unit/**/test*.js --exit'],
     // use `grunt fh:testfile:{{unit_test_filename}}` to run a single test file
     unit_single: ['<%= _test_runner %> <%= _unit_args %> <%= unit_test_filename %>'],
-
     accept: ['turbo --series=true --setUp=test/accept/server.js --tearDown=test/accept/server.js test/accept/test-sys.js test/accept/test-api.js test/accept/test-dataSourceUpdater.js'],
-
     unit_cover: ['istanbul cover --dir cov-unit -- node_modules/.bin/_mocha <%= _unit_args %> --recursive ./test/unit/**/test*.js'],
-
     accept_cover: [
       'istanbul cover --dir cov-accept ./node_modules/.bin/turbo -- --series=true --setUp=test/accept/server.js --tearDown=test/accept/server.js test/accept/test-sys.js test/accept/test-api.js'
     ]

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.6-BUILD-NUMBER",
+  "version": "6.0.7-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "proxyquire": "~1.8.0",
     "should": "2.1.1",
     "sinon": "1.17.0",
-    "supertest": "1.1.0",
+    "supertest": "3.1.0",
     "turbo-test-runner": "http://npm.skunkhenry.com/turbo-test-runner/-/turbo-test-runner-0.6.3.tgz"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "grunt-fh-build": "~2.0.0",
     "istanbul": "0.4.5",
     "license-reporter": "github:bucharest-gold/license-reporter#d74abaf47220137b6dfd3a070556c6d5c4f2003b",
-    "mocha": "~2.5.3",
+    "mocha": "5.2.0",
     "mockgoose": "^7.3.5",
     "proxyquire": "~1.8.0",
     "should": "13.2.1",

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mocha": "~2.5.3",
     "mockgoose": "^7.3.5",
     "proxyquire": "~1.8.0",
-    "should": "2.1.1",
+    "should": "13.2.1",
     "sinon": "1.17.0",
     "supertest": "3.1.0",
     "turbo-test-runner": "http://npm.skunkhenry.com/turbo-test-runner/-/turbo-test-runner-0.6.3.tgz"

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "deep-equal": "~1.0.1",
     "grunt": "~1.0.1",
     "grunt-fh-build": "~2.0.0",
-    "istanbul": "0.4.3",
+    "istanbul": "0.4.5",
     "license-reporter": "github:bucharest-gold/license-reporter#d74abaf47220137b6dfd3a070556c6d5c4f2003b",
     "mocha": "~2.5.3",
     "mockgoose": "^7.3.5",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.6-BUILD-NUMBER",
+  "version": "6.0.7-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20869


# What
Upgrade dev dependencies

# Why
- Get bug fix and updated the project. 
- Allow upgrades and new deps

# How
- Upgrade dev dep supertest from 1.1.0 to 3.1.0 
- Upgrade dev dep should from 2.1.1 to 13.2.1 
- Upgrade dev dep mocha from 2.5.3 to 5.2.0
- Upgrade dev dep istanbul from 0.4.3 to 0.4.5

## Check break changes:

The only break change which affects the project in the above upgreads is regards the version 4.X of mocha, which it will not so long finish the procress and because of it is required used the argument --exit. Currently it was used by default, however, no the default argument in the execution is --no-exit.  See more [here](https://boneskull.com/mocha-v4-nears-release/#mochawontforceexit)

PS.:
The newer versions of `sinon` and `proxyquire` have break changes which will affect the project. These libs were not upgraded because to fix them is required some effort.

# Verification Steps
Check if the CI will finish with success.

## Checklist:

- [ ] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 