### PR TITLE
Rhmap 20884

### DIFF
--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -35,4 +35,4 @@ RUN  mkdir -p /root/licenses/rhmap/ && \
 USER default
 
 ENV FHDEV true
-CMD ["forever","-w","--watchDirectory=/opt/app-root/src","fh-mbaas.js","config/conf.json","--master-only"]
+CMD ["forever","-w","--watchDirectory=/opt/app-root/src", "-c", "node --debug", "fh-mbaas.js","config/conf.json","--master-only"]

--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ For development purposes, we can build a CentOS based Docker image and watch for
 
 1. Generate the config file: `grunt fh-generate-dockerised-config`
 2. `docker build -t docker.io/my-Username/fh-mbaas:dev -f Dockerfile.dev .`
-3. `oc edit dc fh-mbaas`
-4. Replace the image with the tagged version above.
+3. `docker push docker.io/my-Username/fh-mbaas:dev`
+4. `oc edit dc fh-mbaas`
+5. Replace the image with the tagged version above.
 
 ### Hot Deployment
 
@@ -49,7 +50,7 @@ The development image will allow you to sync local code changes to the running c
 
 From the root of the `fh-mbaas directory, run the following:
 
-`oc rsync --no-perms=true ./lib $(oc get po | grep fh-mbaas | grep Running | awk '{print $1}'):/opt/app-root/src`
+`oc rsync --no-perms=true --watch ./lib $(oc get po | grep fh-mbaas | grep Running | awk '{print $1}'):/opt/app-root/src`
 
 ### Debugging with VS Code
 


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-20884


# What
Fixing the CMD in the dev Dockerfile to run this component in debug mode. 


# Why
Having the component run in debug mode allows us to attach a remote debugger (e.g. from VS Code).


# How
When using the forever module, running node in debug mode requires the command to be specified like so `-c "node --debug"`


# Verification Steps
1. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-mbaas-3-xgk72?tab=logs
2. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-mbaas-3-jgcjv?tab=logs
3. Go to https://csteam1.skunkhenry.com:8443/console/project/rhmap-3-node-mbaas/browse/pods/fh-mbaas-3-tp52s?tab=logs
4. Verify that the top of the logs says `Debugger listening on [::]:5858`


## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 