### PR TITLE
log fhconfig

### DIFF
--- a/fh-mbaas.js
+++ b/fh-mbaas.js
@@ -102,6 +102,8 @@ function loadConfig(cb) {
   // read our config file
   var configFile = process.env.conf_file || args._[0];
 
+  console.log(fhconfig);
+
   fhconfig.init(configFile, requiredvalidation, function(err) {
     if (err) {
       return printErrorAndExit("Problems reading config file: " + configFile, err);

--- a/lib/handlers/app/db.js
+++ b/lib/handlers/app/db.js
@@ -9,30 +9,27 @@ exports.getConnectionString = function(req, res, next) {
     if (! appModel || ! appModel.dbConf) {
       return next({"code":404, "message": "no db conf for app"});
     }
-    fhconfig.reload([], function reloaded(err) {
-      if (err) {
-        return next(err);
-      }
 
-      if (mongo.hasUserSpaceDb()) {
-        var mongoUserdbHost = fhconfig.value('mongo_userdb.host');
-        var mongoUserdbPort = fhconfig.value('mongo_userdb.port');
-        var mongoUserdbReplicaSet = fhconfig.value('mongo_userdb.replicaset_name');
-        appModel.dbConf.host = mongoUserdbHost;
-        appModel.dbConf.port = mongoUserdbPort;
-        logger.info({mongoUserdbHost: mongoUserdbHost});
-        req.resultData = {
-          url: mongo.buildConnectionString(appModel.dbConf, mongoUserdbHost, mongoUserdbReplicaSet)
-        };
-        return next();
-      } else { //otherwise return the system db
-          var mongoHost = fhconfig.value('mongo.host');
-          var replicaSet = fhconfig.value('mongo.replicaset_name');
-          logger.info({mongoHost: mongoHost});
-          req.resultData = {
-            url: mongo.buildConnectionString(appModel.dbConf, mongoHost, replicaSet)
-          };
-          return next();
-      }
-    });
+    console.log('IsUserSpace: ' + mongo.hasUserSpaceDb());
+
+    if (mongo.hasUserSpaceDb()) {
+      var mongoUserdbHost = fhconfig.value('mongo_userdb.host');
+      var mongoUserdbPort = fhconfig.value('mongo_userdb.port');
+      var mongoUserdbReplicaSet = fhconfig.value('mongo_userdb.replicaset_name');
+      appModel.dbConf.host = mongoUserdbHost;
+      appModel.dbConf.port = mongoUserdbPort;
+      logger.info({mongoUserdbHost: mongoUserdbHost});
+      req.resultData = {
+        url: mongo.buildConnectionString(appModel.dbConf, mongoUserdbHost, mongoUserdbReplicaSet)
+      };
+      return next();
+    } else { //otherwise return the system db
+      var mongoHost = fhconfig.value('mongo.host');
+      var replicaSet = fhconfig.value('mongo.replicaset_name');
+      logger.info({mongoHost: mongoHost});
+      req.resultData = {
+        url: mongo.buildConnectionString(appModel.dbConf, mongoHost, replicaSet)
+      };
+      return next();
+    }
 };


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21672

# What

fh-mbaas is failing to retrieve the cloud app's connection string.

# Why

Issue is caused by incorrect usage of fh-config api.


# How

It doesn't make much sense to use the reload method: https://github.com/feedhenry/fh-config/blob/master/lib/fhconfig.js#L108 when retrieving the connection string since we were using an empty array as its function argument.

# Verification Steps

* Deploy the fh-mbaas generated by this PR;
* Create a blank project in studio and import the cloud app from this repo: https://github.com/feedhenry/testing-cloud-app;
* Deploy the cloud app and trigger a test by accessing its "/test" route;
* All tests should be green.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 