### PR TITLE
RHMAP-21672 - Downgrade the version of fh-config used

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.8-BUILD-NUMBER",
+  "version": "6.0.9-BUILD-NUMBER",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,773 +1,1114 @@
 {
   "name": "fh-mbaas",
   "version": "6.0.8-BUILD-NUMBER",
+  "lockfileVersion": 1,
+  "requires": true,
   "dependencies": {
     "accepts": {
       "version": "1.3.5",
-      "from": "accepts@>=1.3.4 <1.4.0",
-      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz"
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.5.tgz",
+      "integrity": "sha1-63d99gEXI6OxTopywIBcjoZ0a9I=",
+      "requires": {
+        "mime-types": "~2.1.18",
+        "negotiator": "0.6.1"
+      }
     },
     "acorn": {
       "version": "5.7.1",
-      "from": "acorn@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ=="
     },
     "ajv": {
       "version": "5.5.2",
-      "from": "ajv@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
+      "requires": {
+        "co": "^4.6.0",
+        "fast-deep-equal": "^1.0.0",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.3.0"
+      }
     },
     "align-text": {
       "version": "0.1.4",
-      "from": "align-text@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
+      "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
+      "requires": {
+        "kind-of": "^3.0.2",
+        "longest": "^1.0.1",
+        "repeat-string": "^1.5.2"
+      }
     },
     "amdefine": {
       "version": "1.0.1",
-      "from": "amdefine@>=0.0.4",
-      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
+      "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
     },
     "archiver": {
       "version": "1.2.0",
-      "from": "archiver@1.2.0",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-1.2.0.tgz",
+      "integrity": "sha1-+1xq9UQ7P6akJjRHU7rSp7REqt0=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "async": "^2.0.0",
+        "buffer-crc32": "^0.2.1",
+        "glob": "^7.0.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0",
+        "tar-stream": "^1.5.0",
+        "zip-stream": "^1.1.0"
+      },
       "dependencies": {
         "async": {
           "version": "2.6.1",
-          "from": "async@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+          "integrity": "sha1-skWiPKcZMAROxT+kaqAKPofGphA=",
+          "requires": {
+            "lodash": "^4.17.10"
+          }
         }
       }
     },
     "archiver-utils": {
       "version": "1.3.0",
-      "from": "archiver-utils@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/archiver-utils/-/archiver-utils-1.3.0.tgz",
+      "integrity": "sha1-5QtMCccL89aA4y/xt5lOn52JUXQ=",
+      "requires": {
+        "glob": "^7.0.0",
+        "graceful-fs": "^4.1.0",
+        "lazystream": "^1.0.0",
+        "lodash": "^4.8.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
     },
     "array-flatten": {
       "version": "1.1.1",
-      "from": "array-flatten@1.1.1",
-      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
     },
     "asn1": {
       "version": "0.2.3",
-      "from": "asn1@>=0.2.3 <0.3.0",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
     },
     "assert-plus": {
       "version": "1.0.0",
-      "from": "assert-plus@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
     },
     "async": {
       "version": "1.5.2",
-      "from": "async@1.5.2",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+      "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
     },
     "asynckit": {
       "version": "0.4.0",
-      "from": "asynckit@>=0.4.0 <0.5.0",
-      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "aws-sign2": {
       "version": "0.7.0",
-      "from": "aws-sign2@>=0.7.0 <0.8.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
     },
     "aws4": {
       "version": "1.7.0",
-      "from": "aws4@>=1.6.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.7.0.tgz",
+      "integrity": "sha1-1NDpudv8p3vwjusKikcVUP454ok="
     },
     "balanced-match": {
       "version": "1.0.0",
-      "from": "balanced-match@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
+    },
+    "bcrypt-pbkdf": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+      "optional": true,
+      "requires": {
+        "tweetnacl": "^0.14.3"
+      }
     },
     "bl": {
       "version": "1.2.2",
-      "from": "bl@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.2.tgz",
+      "integrity": "sha1-oWCRFxcQPAdBDO9j71Gzl8Alr5w=",
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "bluebird": {
       "version": "3.5.1",
-      "from": "bluebird@>=3.5.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+      "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
     },
     "body-parser": {
       "version": "1.18.2",
-      "from": "body-parser@1.18.2",
-      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+      "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+      "requires": {
+        "bytes": "3.0.0",
+        "content-type": "~1.0.4",
+        "debug": "2.6.9",
+        "depd": "~1.1.1",
+        "http-errors": "~1.6.2",
+        "iconv-lite": "0.4.19",
+        "on-finished": "~2.3.0",
+        "qs": "6.5.1",
+        "raw-body": "2.3.2",
+        "type-is": "~1.6.15"
+      }
     },
     "boom": {
       "version": "4.3.1",
-      "from": "boom@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "requires": {
+        "hoek": "4.x.x"
+      }
     },
     "brace-expansion": {
       "version": "1.1.11",
-      "from": "brace-expansion@>=1.1.7 <2.0.0",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz"
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha1-PH/L9SnYcibz0vUrlm/1Jx60Qd0=",
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
     },
     "brfs": {
       "version": "1.4.4",
-      "from": "brfs@>=1.4.4 <1.5.0",
-      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.4.tgz"
+      "resolved": "https://registry.npmjs.org/brfs/-/brfs-1.4.4.tgz",
+      "integrity": "sha1-/DFrxIgBgPqO4lvKq2X4aRDOHdU=",
+      "requires": {
+        "quote-stream": "^1.0.1",
+        "resolve": "^1.1.5",
+        "static-module": "^2.1.1",
+        "through2": "^2.0.0"
+      }
     },
     "bson": {
       "version": "0.4.23",
-      "from": "bson@>=0.4.21 <0.5.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+      "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+      "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
     },
     "buffer-alloc": {
       "version": "1.2.0",
-      "from": "buffer-alloc@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha1-iQ3ZDZI6hz4I4Q5f1RpX5bfM4Ow=",
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
     },
     "buffer-alloc-unsafe": {
       "version": "1.1.0",
-      "from": "buffer-alloc-unsafe@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha1-vX3CauKXLQ7aJTvgYdupkjScGfA="
     },
     "buffer-crc32": {
       "version": "0.2.13",
-      "from": "buffer-crc32@>=0.2.1 <0.3.0",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
+      "integrity": "sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI="
     },
     "buffer-equal": {
       "version": "0.0.1",
-      "from": "buffer-equal@0.0.1",
-      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-equal/-/buffer-equal-0.0.1.tgz",
+      "integrity": "sha1-kbx0sR6kBbyRa8aqkI+q+ltKrEs="
     },
     "buffer-fill": {
       "version": "1.0.0",
-      "from": "buffer-fill@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw="
     },
     "buffer-from": {
       "version": "1.1.0",
-      "from": "buffer-from@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha1-h/yqOimDWOCt5uRCz86EB0DRrQQ="
     },
     "buffer-shims": {
       "version": "1.0.0",
-      "from": "buffer-shims@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
     },
     "bunyan": {
       "version": "1.8.12",
-      "from": "bunyan@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz"
+      "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.12.tgz",
+      "integrity": "sha1-8VDw9nSKvdcq6uhPBEA74u8RN5c=",
+      "requires": {
+        "dtrace-provider": "~0.8",
+        "moment": "^2.10.6",
+        "mv": "~2",
+        "safe-json-stringify": "~1"
+      }
     },
     "busboy": {
       "version": "0.2.14",
-      "from": "busboy@>=0.2.9 <0.3.0",
       "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
+      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "requires": {
+        "dicer": "0.2.5",
+        "readable-stream": "1.1.x"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "bytes": {
       "version": "3.0.0",
-      "from": "bytes@3.0.0",
-      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+      "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
     },
     "camelcase": {
       "version": "1.2.1",
-      "from": "camelcase@>=1.0.2 <2.0.0",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "integrity": "sha1-m7UwTS4LVmmLLHWLCKPqqdqlijk=",
       "optional": true
     },
     "caseless": {
       "version": "0.12.0",
-      "from": "caseless@>=0.12.0 <0.13.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "center-align": {
       "version": "0.1.3",
-      "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
-      "optional": true
+      "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.3",
+        "lazy-cache": "^1.0.3"
+      }
     },
     "cliui": {
       "version": "2.1.0",
-      "from": "cliui@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "optional": true,
+      "requires": {
+        "center-align": "^0.1.1",
+        "right-align": "^0.1.1",
+        "wordwrap": "0.0.2"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
-          "from": "wordwrap@0.0.2",
           "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "integrity": "sha1-t5Zpu0LstAn4PVg8rVLKF+qhZD8=",
           "optional": true
         }
       }
     },
     "co": {
       "version": "4.6.0",
-      "from": "co@>=4.6.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
     },
     "colors": {
       "version": "1.0.3",
-      "from": "colors@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/colors/-/colors-1.0.3.tgz",
+      "integrity": "sha1-BDP0TYCWgP3rYO0mDxsMJi6CpAs="
     },
     "combined-stream": {
       "version": "1.0.6",
-      "from": "combined-stream@>=1.0.5 <1.1.0",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.6.tgz",
+      "integrity": "sha1-cj599ugBrFYTETp+RFqbactjKBg=",
+      "requires": {
+        "delayed-stream": "~1.0.0"
+      }
     },
     "compress-commons": {
       "version": "1.2.2",
-      "from": "compress-commons@>=1.2.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/compress-commons/-/compress-commons-1.2.2.tgz",
+      "integrity": "sha1-UkqfEJA/OoEzibAiXSfEi7dRiQ8=",
+      "requires": {
+        "buffer-crc32": "^0.2.1",
+        "crc32-stream": "^2.0.0",
+        "normalize-path": "^2.0.0",
+        "readable-stream": "^2.0.0"
+      }
     },
     "concat-map": {
       "version": "0.0.1",
-      "from": "concat-map@0.0.1",
-      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "concat-stream": {
       "version": "1.6.2",
-      "from": "concat-stream@1.6.2",
-      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz"
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha1-kEvfGUzTEi/Gdcd/xKw9T/D9GjQ=",
+      "requires": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
     },
     "content-disposition": {
       "version": "0.5.2",
-      "from": "content-disposition@0.5.2",
-      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+      "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
     },
     "content-type": {
       "version": "1.0.4",
-      "from": "content-type@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+      "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
     },
     "convert-source-map": {
       "version": "1.5.1",
-      "from": "convert-source-map@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.5.1.tgz",
+      "integrity": "sha1-uCeAl7m8IpNl3lxiz1/K7YtVmeU="
     },
     "cookie": {
       "version": "0.3.1",
-      "from": "cookie@0.3.1",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+      "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
     },
     "cookie-signature": {
       "version": "1.0.6",
-      "from": "cookie-signature@1.0.6",
-      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
     },
     "core-util-is": {
       "version": "1.0.2",
-      "from": "core-util-is@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cors": {
       "version": "2.7.1",
-      "from": "cors@2.7.1",
-      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz"
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.7.1.tgz",
+      "integrity": "sha1-PC5QpYr574yJvuISJrCZvh8Cc5s=",
+      "requires": {
+        "vary": "^1"
+      }
     },
     "crc": {
       "version": "3.5.0",
-      "from": "crc@>=3.4.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/crc/-/crc-3.5.0.tgz",
+      "integrity": "sha1-mLi6fUiWZbo5efWbITgTdBAaGWQ="
     },
     "crc32-stream": {
       "version": "2.0.0",
-      "from": "crc32-stream@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/crc32-stream/-/crc32-stream-2.0.0.tgz",
+      "integrity": "sha1-483TtN8xaN10494/u8t7KX/pCPQ=",
+      "requires": {
+        "crc": "^3.4.4",
+        "readable-stream": "^2.0.0"
+      }
     },
     "cron": {
       "version": "1.1.1",
-      "from": "cron@>=1.1.0 <1.2.0",
-      "resolved": "https://registry.npmjs.org/cron/-/cron-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/cron/-/cron-1.1.1.tgz",
+      "integrity": "sha1-AnGdTvSA38juJNgaNgNGC6OQE84=",
+      "requires": {
+        "moment-timezone": "~0.5.5"
+      }
     },
     "cryptiles": {
       "version": "3.1.2",
-      "from": "cryptiles@>=3.0.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "requires": {
+        "boom": "5.x.x"
+      },
       "dependencies": {
         "boom": {
           "version": "5.2.0",
-          "from": "boom@>=5.0.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+          "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
         }
       }
     },
     "cycle": {
       "version": "1.0.3",
-      "from": "cycle@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+      "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
     },
     "dashdash": {
       "version": "1.14.1",
-      "from": "dashdash@>=1.12.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "date.js": {
       "version": "0.3.3",
-      "from": "date.js@>=0.3.1 <0.4.0",
       "resolved": "https://registry.npmjs.org/date.js/-/date.js-0.3.3.tgz",
+      "integrity": "sha1-7x6SMy9QemOHldu5helRiC5Qu9o=",
+      "requires": {
+        "debug": "~3.1.0"
+      },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
-          "from": "debug@>=3.1.0 <3.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha1-W7WgZyYotkFJVmuhaBnmFRjGcmE=",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },
     "debug": {
       "version": "2.6.9",
-      "from": "debug@2.6.9",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+      "requires": {
+        "ms": "2.0.0"
+      }
     },
     "decamelize": {
       "version": "1.2.0",
-      "from": "decamelize@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+      "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=",
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.3",
-      "from": "deep-is@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
     },
     "delayed-stream": {
       "version": "1.0.0",
-      "from": "delayed-stream@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "depd": {
       "version": "1.1.2",
-      "from": "depd@>=1.1.1 <1.2.0",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak="
     },
     "destroy": {
       "version": "1.0.4",
-      "from": "destroy@>=1.0.4 <1.1.0",
-      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+      "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
     },
     "dicer": {
       "version": "0.2.5",
-      "from": "dicer@0.2.5",
       "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
+      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
+      "requires": {
+        "readable-stream": "1.1.x",
+        "streamsearch": "0.1.2"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "readable-stream": {
           "version": "1.1.14",
-          "from": "readable-stream@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
+          "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "diskspace": {
       "version": "1.0.2",
-      "from": "diskspace@1.0.2",
-      "resolved": "https://registry.npmjs.org/diskspace/-/diskspace-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/diskspace/-/diskspace-1.0.2.tgz",
+      "integrity": "sha1-D4I+DSXmu7EaXC/6rWjD+zuvGmE="
     },
     "dtrace-provider": {
       "version": "0.8.7",
-      "from": "dtrace-provider@>=0.8.0 <0.9.0",
       "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.7.tgz",
-      "optional": true
+      "integrity": "sha1-3JObTT4GIM/gwc2APQ0tftBP/QQ=",
+      "optional": true,
+      "requires": {
+        "nan": "^2.10.0"
+      }
     },
     "duplexer2": {
       "version": "0.1.4",
-      "from": "duplexer2@>=0.1.4 <0.2.0",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz"
+      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+      "requires": {
+        "readable-stream": "^2.0.2"
+      }
+    },
+    "ecc-jsbn": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
+      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+      "optional": true,
+      "requires": {
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.1.0"
+      }
     },
     "ee-first": {
       "version": "1.1.1",
-      "from": "ee-first@1.1.1",
-      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
     },
     "encodeurl": {
       "version": "1.0.2",
-      "from": "encodeurl@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k="
     },
     "end-of-stream": {
       "version": "1.4.1",
-      "from": "end-of-stream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.1.tgz",
+      "integrity": "sha1-7SljTRm6ukY7bOa4CjchPqtx7EM=",
+      "requires": {
+        "once": "^1.4.0"
+      }
     },
     "es6-promise": {
       "version": "3.0.2",
-      "from": "es6-promise@3.0.2",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+      "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
     },
     "escape-html": {
       "version": "1.0.3",
-      "from": "escape-html@>=1.0.3 <1.1.0",
-      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
     },
     "escodegen": {
       "version": "1.9.1",
-      "from": "escodegen@>=1.9.0 <1.10.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
+      "integrity": "sha1-264X75bI5L7bE1b0UE+kzC98t+I=",
+      "requires": {
+        "esprima": "^3.1.3",
+        "estraverse": "^4.2.0",
+        "esutils": "^2.0.2",
+        "optionator": "^0.8.1",
+        "source-map": "~0.6.1"
+      }
     },
     "esprima": {
       "version": "3.1.3",
-      "from": "esprima@>=3.1.3 <4.0.0",
-      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
+      "integrity": "sha1-/cpRzuYTOJXjyI1TXOSdv/YqRjM="
     },
     "estraverse": {
       "version": "4.2.0",
-      "from": "estraverse@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM="
     },
     "esutils": {
       "version": "2.0.2",
-      "from": "esutils@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "etag": {
       "version": "1.8.1",
-      "from": "etag@>=1.8.1 <1.9.0",
-      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
     },
     "express": {
       "version": "4.16.3",
-      "from": "express@4.16.3",
-      "resolved": "https://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "resolved": "http://registry.npmjs.org/express/-/express-4.16.3.tgz",
+      "integrity": "sha1-avilAjUNsyRuzEvs9rWjTSL37VM=",
+      "requires": {
+        "accepts": "~1.3.5",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.18.2",
+        "content-disposition": "0.5.2",
+        "content-type": "~1.0.4",
+        "cookie": "0.3.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.1.1",
+        "fresh": "0.5.2",
+        "merge-descriptors": "1.0.1",
+        "methods": "~1.1.2",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "path-to-regexp": "0.1.7",
+        "proxy-addr": "~2.0.3",
+        "qs": "6.5.1",
+        "range-parser": "~1.2.0",
+        "safe-buffer": "5.1.1",
+        "send": "0.16.2",
+        "serve-static": "1.13.2",
+        "setprototypeof": "1.1.0",
+        "statuses": "~1.4.0",
+        "type-is": "~1.6.16",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
       "dependencies": {
         "safe-buffer": {
           "version": "5.1.1",
-          "from": "safe-buffer@5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg=="
         },
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@>=1.4.0 <1.5.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "express-bunyan-logger": {
       "version": "1.3.3",
-      "from": "express-bunyan-logger@1.3.3",
-      "resolved": "https://registry.npmjs.org/express-bunyan-logger/-/express-bunyan-logger-1.3.3.tgz"
+      "resolved": "https://registry.npmjs.org/express-bunyan-logger/-/express-bunyan-logger-1.3.3.tgz",
+      "integrity": "sha512-gUBcdgpvreonvAVwDvUKtyMsOMZ3Md8wuxEJqDvbNS9o0NlHzlQa0z97vjQUTnzwi39xvjnxaFr8izKFl20WvQ==",
+      "requires": {
+        "bunyan": "^1.8.12",
+        "lodash.has": "^4.5.2",
+        "lodash.set": "^4.3.2",
+        "useragent": "^2.2.1",
+        "uuid": "^3.1.0"
+      }
     },
     "express-paginate": {
       "version": "1.0.0",
-      "from": "express-paginate@1.0.0",
-      "resolved": "https://registry.npmjs.org/express-paginate/-/express-paginate-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/express-paginate/-/express-paginate-1.0.0.tgz",
+      "integrity": "sha512-M4+ee9YdcRoBltBYBwMcZUH589KeoVy62dBTyaZXlrggnJFGvk3Rgw0XYdL2PXN0BQROrnYskw+QxtoPsdY+AQ==",
+      "requires": {
+        "lodash.assign": "^4.2.0",
+        "lodash.clone": "^4.5.0",
+        "lodash.isobject": "^3.0.2",
+        "qs": "^6.5.1"
+      }
     },
     "extend": {
       "version": "3.0.1",
-      "from": "extend@>=3.0.1 <3.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+      "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
     },
     "extract-zip": {
       "version": "1.6.7",
-      "from": "extract-zip@>=1.6.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz"
+      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-1.6.7.tgz",
+      "integrity": "sha1-qEC0uK9kAyZMjbV/Txp0Mz74H+k=",
+      "requires": {
+        "concat-stream": "1.6.2",
+        "debug": "2.6.9",
+        "mkdirp": "0.5.1",
+        "yauzl": "2.4.1"
+      }
     },
     "extsprintf": {
       "version": "1.3.0",
-      "from": "extsprintf@1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
     },
     "eyes": {
       "version": "0.1.8",
-      "from": "eyes@>=0.1.0 <0.2.0",
-      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+      "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+      "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
     },
     "falafel": {
       "version": "2.1.0",
-      "from": "falafel@>=2.1.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.1.0.tgz",
+      "integrity": "sha1-lrsXdh2rqU9G0AFzizzt86Z/4Gw=",
+      "requires": {
+        "acorn": "^5.0.0",
+        "foreach": "^2.0.5",
+        "isarray": "0.0.1",
+        "object-keys": "^1.0.6"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         }
       }
     },
     "fast-deep-equal": {
       "version": "1.1.0",
-      "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.1.0.tgz",
+      "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ="
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
-      "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
     },
     "fast-levenshtein": {
       "version": "2.0.6",
-      "from": "fast-levenshtein@>=2.0.4 <2.1.0",
-      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
     },
     "fd-slicer": {
       "version": "1.0.1",
-      "from": "fd-slicer@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
+      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "requires": {
+        "pend": "~1.2.0"
+      }
     },
     "fh-agenda": {
       "version": "0.9.0",
-      "from": "fh-agenda@0.9.0",
       "resolved": "https://registry.npmjs.org/fh-agenda/-/fh-agenda-0.9.0.tgz",
+      "integrity": "sha1-qlfCZfiRzK9gka9fChD1Hh0M+JI=",
+      "requires": {
+        "cron": "~1.1.0",
+        "date.js": "~0.3.1",
+        "human-interval": "~0.1.3",
+        "moment-timezone": "^0.5.0",
+        "mongodb": "2.1.11"
+      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "mongodb": {
           "version": "2.1.11",
-          "from": "mongodb@2.1.11",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.11.tgz"
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.11.tgz",
+          "integrity": "sha1-PpxW4HcOB19yVO6ZF806ym7QJN4=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.3.10",
+            "readable-stream": "1.0.31"
+          }
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
     "fh-amqp-js": {
       "version": "0.7.5",
-      "from": "fh-amqp-js@0.7.5",
       "resolved": "https://registry.npmjs.org/fh-amqp-js/-/fh-amqp-js-0.7.5.tgz",
+      "integrity": "sha1-Vr/eKo8M2nlJLC9nnao7IKj0tBA=",
+      "requires": {
+        "amqp": "0.2.6",
+        "async": "1.5.2",
+        "lodash": "4.17.10",
+        "node-uuid": "^1.4.4",
+        "rc": "1.2.8"
+      },
       "dependencies": {
         "amqp": {
           "version": "0.2.6",
-          "from": "amqp@0.2.6",
-          "resolved": "https://registry.npmjs.org/amqp/-/amqp-0.2.6.tgz"
+          "resolved": "https://registry.npmjs.org/amqp/-/amqp-0.2.6.tgz",
+          "integrity": "sha1-2X/uUUMCb6C0/WpdVkhfBEjrN8o=",
+          "requires": {
+            "lodash": "^4.0.0"
+          }
         },
         "async": {
           "version": "1.5.2",
-          "from": "async@1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "deep-extend": {
           "version": "0.6.0",
-          "from": "deep-extend@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
         },
         "ini": {
           "version": "1.3.5",
-          "from": "ini@>=1.3.0 <1.4.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz"
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
+          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
         },
         "lodash": {
           "version": "4.17.10",
-          "from": "lodash@4.17.10",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+          "integrity": "sha512-UejweD1pDoXu+AD825lWwp4ZGtSwgnpZxb3JDViD7StjQz+Nb/6l093lx4OQ0foGWNRoc19mWy7BzL+UAK2iVg=="
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         },
         "node-uuid": {
           "version": "1.4.8",
-          "from": "node-uuid@>=1.4.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.8.tgz",
+          "integrity": "sha1-sEDrCSOWivq/jTL7HxfxFn/auQc="
         },
         "rc": {
           "version": "1.2.8",
-          "from": "rc@1.2.8",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz"
+          "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "requires": {
+            "deep-extend": "^0.6.0",
+            "ini": "~1.3.0",
+            "minimist": "^1.2.0",
+            "strip-json-comments": "~2.0.1"
+          }
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "from": "strip-json-comments@>=2.0.1 <2.1.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
         }
       }
     },
     "fh-cls-mongoose": {
       "version": "2.1.1",
-      "from": "fh-cls-mongoose@2.1.1",
-      "resolved": "https://registry.npmjs.org/fh-cls-mongoose/-/fh-cls-mongoose-2.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/fh-cls-mongoose/-/fh-cls-mongoose-2.1.1.tgz",
+      "integrity": "sha1-JMzjgwR6or1KayKpZh8c71ldCJQ=",
+      "requires": {
+        "shimmer": "^1"
+      }
     },
     "fh-cluster": {
       "version": "0.3.0",
-      "from": "fh-cluster@0.3.0",
       "resolved": "https://registry.npmjs.org/fh-cluster/-/fh-cluster-0.3.0.tgz",
+      "integrity": "sha1-Z8YOK1+ftMfueb556IzkN+NAK7I=",
+      "requires": {
+        "backoff": "2.4.1",
+        "lodash": "3.10.1"
+      },
       "dependencies": {
         "backoff": {
           "version": "2.4.1",
-          "from": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
           "resolved": "https://registry.npmjs.org/backoff/-/backoff-2.4.1.tgz",
+          "integrity": "sha1-L2jFDg3Xidvv4kIApi77BNJFbWg=",
+          "requires": {
+            "precond": "0.2"
+          },
           "dependencies": {
             "precond": {
               "version": "0.2.3",
-              "from": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
-              "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz"
+              "resolved": "https://registry.npmjs.org/precond/-/precond-0.2.3.tgz",
+              "integrity": "sha1-qpWRvKokkj8eD0hJ0kD0fvwQdaw="
             }
           }
         },
         "lodash": {
           "version": "3.10.1",
-          "from": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+          "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
         }
       }
     },
     "fh-component-metrics": {
       "version": "2.7.0",
-      "from": "fh-component-metrics@2.7.0",
       "resolved": "https://registry.npmjs.org/fh-component-metrics/-/fh-component-metrics-2.7.0.tgz",
+      "integrity": "sha1-2FX+SJ2SE49wfnTUfmhfTDQ8QkI=",
+      "requires": {
+        "async": "2.1.5",
+        "lodash": "4.17.4"
+      },
       "dependencies": {
         "async": {
           "version": "2.1.5",
-          "from": "async@2.1.5",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.5.tgz",
+          "integrity": "sha1-5YfGhYCZSsZ/xW/4bTrFa9voELw=",
+          "requires": {
+            "lodash": "^4.14.0"
+          }
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         }
       }
     },
     "fh-config": {
-      "version": "2.0.0",
-      "from": "fh-config@2.0.0",
-      "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-2.0.0.tgz",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-1.0.3.tgz",
+      "integrity": "sha1-GWqhOEE8LG60jVH/AuUbsVkIFO4=",
+      "requires": {
+        "async": "^0.9.0",
+        "bunyan": "^1.1.3",
+        "dateformat": "^1.0.8",
+        "underscore": "^1.8.3",
+        "winston": "^0.8.1"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "bunyan": {
           "version": "1.8.4",
-          "from": "bunyan@>=1.1.3 <2.0.0",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.4.tgz",
+          "integrity": "sha1-mAE6zIEuvDgGNkBJ7fbJEp2LjXM=",
+          "requires": {
+            "dtrace-provider": "~0.7",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
+          },
           "dependencies": {
             "dtrace-provider": {
               "version": "0.7.1",
-              "from": "dtrace-provider@>=0.7.0 <0.8.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.7.1.tgz",
+              "integrity": "sha1-wGswjy8Q1dWDiuycVx5dWI3HHQQ=",
               "optional": true,
+              "requires": {
+                "nan": "^2.3.3"
+              },
               "dependencies": {
                 "nan": {
                   "version": "2.4.0",
-                  "from": "nan@>=2.3.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.4.0.tgz",
+                  "integrity": "sha1-+zxZ1F/k7/4hXwuJD4rfbrMtIjI=",
                   "optional": true
                 }
               }
             },
             "moment": {
               "version": "2.15.2",
-              "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.15.2.tgz",
+              "resolved": "http://registry.npmjs.org/moment/-/moment-2.15.2.tgz",
+              "integrity": "sha1-G/3t9qbjRfMi/pVtXfW9CKjOhNw=",
               "optional": true
             },
             "mv": {
               "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
+              "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+              },
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                       "optional": true
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                  "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                   "optional": true
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
+                  "requires": {
+                    "glob": "^6.0.1"
+                  },
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
+                      "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                      },
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "optional": true,
+                          "requires": {
+                            "once": "^1.3.0",
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                               "optional": true
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                           "optional": true
                         },
                         "minimatch": {
                           "version": "3.0.3",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.3.tgz",
+                          "integrity": "sha1-Kk5AkLlrLbBqnX3wEFWmKnfJt3Q=",
                           "optional": true,
+                          "requires": {
+                            "brace-expansion": "^1.0.0"
+                          },
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.6",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.6.tgz",
+                              "integrity": "sha1-cZfX6qm4fmSDkOph/GbIRCdCDfk=",
                               "optional": true,
+                              "requires": {
+                                "balanced-match": "^0.4.1",
+                                "concat-map": "0.0.1"
+                              },
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.2",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
+                                  "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
                                   "optional": true
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                   "optional": true
                                 }
                               }
@@ -776,20 +1117,23 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                          "requires": {
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                           "optional": true
                         }
                       }
@@ -800,126 +1144,169 @@
             },
             "safe-json-stringify": {
               "version": "1.0.3",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+              "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
               "optional": true
             }
           }
         },
         "dateformat": {
           "version": "1.0.12",
-          "from": "dateformat@>=1.0.8 <2.0.0",
           "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
+          "integrity": "sha1-nxJLZ1lMk3/3BpMuSmQsyo27/uk=",
+          "requires": {
+            "get-stdin": "^4.0.1",
+            "meow": "^3.3.0"
+          },
           "dependencies": {
             "get-stdin": {
               "version": "4.0.1",
-              "from": "get-stdin@>=4.0.1 <5.0.0",
-              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-4.0.1.tgz",
+              "integrity": "sha1-uWjGsKBDhDJJAui/Gl3zJXmkUP4="
             },
             "meow": {
               "version": "3.7.0",
-              "from": "meow@>=3.3.0 <4.0.0",
               "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
+              "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
+              "requires": {
+                "camelcase-keys": "^2.0.0",
+                "decamelize": "^1.1.2",
+                "loud-rejection": "^1.0.0",
+                "map-obj": "^1.0.1",
+                "minimist": "^1.1.3",
+                "normalize-package-data": "^2.3.4",
+                "object-assign": "^4.0.1",
+                "read-pkg-up": "^1.0.1",
+                "redent": "^1.0.0",
+                "trim-newlines": "^1.0.0"
+              },
               "dependencies": {
                 "camelcase-keys": {
                   "version": "2.1.0",
-                  "from": "camelcase-keys@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
+                  "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
+                  "requires": {
+                    "camelcase": "^2.0.0",
+                    "map-obj": "^1.0.0"
+                  },
                   "dependencies": {
                     "camelcase": {
                       "version": "2.1.1",
-                      "from": "camelcase@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz"
+                      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-2.1.1.tgz",
+                      "integrity": "sha1-fB0W1nmhu+WcoCys7PsBHiAfWh8="
                     }
                   }
                 },
                 "decamelize": {
                   "version": "1.2.0",
-                  "from": "decamelize@>=1.1.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz",
+                  "integrity": "sha1-9lNNFRSCabIDUue+4m9QH5oZEpA="
                 },
                 "loud-rejection": {
                   "version": "1.6.0",
-                  "from": "loud-rejection@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
+                  "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
+                  "requires": {
+                    "currently-unhandled": "^0.4.1",
+                    "signal-exit": "^3.0.0"
+                  },
                   "dependencies": {
                     "currently-unhandled": {
                       "version": "0.4.1",
-                      "from": "currently-unhandled@>=0.4.1 <0.5.0",
                       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
+                      "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
+                      "requires": {
+                        "array-find-index": "^1.0.1"
+                      },
                       "dependencies": {
                         "array-find-index": {
                           "version": "1.0.2",
-                          "from": "array-find-index@>=1.0.1 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
+                          "integrity": "sha1-3wEKoSh+Fku9pvlyOwqWoexBh6E="
                         }
                       }
                     },
                     "signal-exit": {
                       "version": "3.0.1",
-                      "from": "signal-exit@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.1.tgz",
+                      "integrity": "sha1-WkyISZK2OnrNm623iUw+6c/MrYE="
                     }
                   }
                 },
                 "map-obj": {
                   "version": "1.0.1",
-                  "from": "map-obj@>=1.0.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/map-obj/-/map-obj-1.0.1.tgz",
+                  "integrity": "sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0="
                 },
                 "minimist": {
                   "version": "1.2.0",
-                  "from": "minimist@>=1.1.3 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+                  "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+                  "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
                 },
                 "normalize-package-data": {
                   "version": "2.3.5",
-                  "from": "normalize-package-data@>=2.3.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.3.5.tgz",
+                  "integrity": "sha1-jZJPFClg4Xd+f/4XBUNjHMfLAt8=",
+                  "requires": {
+                    "hosted-git-info": "^2.1.4",
+                    "is-builtin-module": "^1.0.0",
+                    "semver": "2 || 3 || 4 || 5",
+                    "validate-npm-package-license": "^3.0.1"
+                  },
                   "dependencies": {
                     "hosted-git-info": {
                       "version": "2.1.5",
-                      "from": "hosted-git-info@>=2.1.4 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz"
+                      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.1.5.tgz",
+                      "integrity": "sha1-C6gdkNouJas0ozLm7HeTbhWYEYs="
                     },
                     "is-builtin-module": {
                       "version": "1.0.0",
-                      "from": "is-builtin-module@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
+                      "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
+                      "requires": {
+                        "builtin-modules": "^1.0.0"
+                      },
                       "dependencies": {
                         "builtin-modules": {
                           "version": "1.1.1",
-                          "from": "builtin-modules@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/builtin-modules/-/builtin-modules-1.1.1.tgz",
+                          "integrity": "sha1-Jw8HbFpywC9bZaR9+Uxf46J4iS8="
                         }
                       }
                     },
                     "semver": {
                       "version": "5.3.0",
-                      "from": "semver@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0||>=4.0.0 <5.0.0||>=5.0.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz",
+                      "integrity": "sha1-myzl094C0XxgEq0yaqa00M9U+U8="
                     },
                     "validate-npm-package-license": {
                       "version": "3.0.1",
-                      "from": "validate-npm-package-license@>=3.0.1 <4.0.0",
                       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
+                      "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
+                      "requires": {
+                        "spdx-correct": "~1.0.0",
+                        "spdx-expression-parse": "~1.0.0"
+                      },
                       "dependencies": {
                         "spdx-correct": {
                           "version": "1.0.2",
-                          "from": "spdx-correct@>=1.0.0 <1.1.0",
                           "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
+                          "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
+                          "requires": {
+                            "spdx-license-ids": "^1.0.2"
+                          },
                           "dependencies": {
                             "spdx-license-ids": {
                               "version": "1.2.2",
-                              "from": "spdx-license-ids@>=1.0.2 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz"
+                              "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-1.2.2.tgz",
+                              "integrity": "sha1-yd96NCRZSt5r0RkA1ZZpbcBrrFc="
                             }
                           }
                         },
                         "spdx-expression-parse": {
                           "version": "1.0.4",
-                          "from": "spdx-expression-parse@>=1.0.0 <1.1.0",
-                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz"
+                          "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-1.0.4.tgz",
+                          "integrity": "sha1-m98vIOH0DtRH++JzJmGR/O1RYmw="
                         }
                       }
                     }
@@ -927,33 +1314,47 @@
                 },
                 "object-assign": {
                   "version": "4.1.0",
-                  "from": "object-assign@>=4.0.1 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz",
+                  "integrity": "sha1-ejs9DpgGPUP0wD8uiubNUahog6A="
                 },
                 "read-pkg-up": {
                   "version": "1.0.1",
-                  "from": "read-pkg-up@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
+                  "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
+                  "requires": {
+                    "find-up": "^1.0.0",
+                    "read-pkg": "^1.0.0"
+                  },
                   "dependencies": {
                     "find-up": {
                       "version": "1.1.2",
-                      "from": "find-up@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
+                      "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
+                      "requires": {
+                        "path-exists": "^2.0.0",
+                        "pinkie-promise": "^2.0.0"
+                      },
                       "dependencies": {
                         "path-exists": {
                           "version": "2.1.0",
-                          "from": "path-exists@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz"
+                          "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
+                          "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
+                          "requires": {
+                            "pinkie-promise": "^2.0.0"
+                          }
                         },
                         "pinkie-promise": {
                           "version": "2.0.1",
-                          "from": "pinkie-promise@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                          "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                          "requires": {
+                            "pinkie": "^2.0.0"
+                          },
                           "dependencies": {
                             "pinkie": {
                               "version": "2.0.4",
-                              "from": "pinkie@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                              "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                              "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
                             }
                           }
                         }
@@ -961,33 +1362,51 @@
                     },
                     "read-pkg": {
                       "version": "1.1.0",
-                      "from": "read-pkg@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
+                      "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
+                      "requires": {
+                        "load-json-file": "^1.0.0",
+                        "normalize-package-data": "^2.3.2",
+                        "path-type": "^1.0.0"
+                      },
                       "dependencies": {
                         "load-json-file": {
                           "version": "1.1.0",
-                          "from": "load-json-file@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
+                          "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "parse-json": "^2.2.0",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0",
+                            "strip-bom": "^2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.9",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
                             },
                             "parse-json": {
                               "version": "2.2.0",
-                              "from": "parse-json@>=2.2.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+                              "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+                              "requires": {
+                                "error-ex": "^1.2.0"
+                              },
                               "dependencies": {
                                 "error-ex": {
                                   "version": "1.3.0",
-                                  "from": "error-ex@>=1.2.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.0.tgz",
+                                  "integrity": "sha1-5ntD8+gsluo6WE/+4Ln8MyXYAtk=",
+                                  "requires": {
+                                    "is-arrayish": "^0.2.1"
+                                  },
                                   "dependencies": {
                                     "is-arrayish": {
                                       "version": "0.2.1",
-                                      "from": "is-arrayish@>=0.2.1 <0.3.0",
-                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz"
+                                      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+                                      "integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
                                     }
                                   }
                                 }
@@ -995,30 +1414,36 @@
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
                                 }
                               }
                             },
                             "strip-bom": {
                               "version": "2.0.0",
-                              "from": "strip-bom@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
+                              "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
+                              "requires": {
+                                "is-utf8": "^0.2.0"
+                              },
                               "dependencies": {
                                 "is-utf8": {
                                   "version": "0.2.1",
-                                  "from": "is-utf8@>=0.2.0 <0.3.0",
-                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/is-utf8/-/is-utf8-0.2.1.tgz",
+                                  "integrity": "sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI="
                                 }
                               }
                             }
@@ -1026,28 +1451,36 @@
                         },
                         "path-type": {
                           "version": "1.1.0",
-                          "from": "path-type@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
+                          "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
+                          "requires": {
+                            "graceful-fs": "^4.1.2",
+                            "pify": "^2.0.0",
+                            "pinkie-promise": "^2.0.0"
+                          },
                           "dependencies": {
                             "graceful-fs": {
                               "version": "4.1.9",
-                              "from": "graceful-fs@>=4.1.2 <5.0.0",
-                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz"
+                              "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.9.tgz",
+                              "integrity": "sha1-uqy6N9GdEfnRRtNXi8mZWMN4fik="
                             },
                             "pify": {
                               "version": "2.3.0",
-                              "from": "pify@>=2.0.0 <3.0.0",
-                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz"
+                              "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+                              "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw="
                             },
                             "pinkie-promise": {
                               "version": "2.0.1",
-                              "from": "pinkie-promise@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                              "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                              "requires": {
+                                "pinkie": "^2.0.0"
+                              },
                               "dependencies": {
                                 "pinkie": {
                                   "version": "2.0.4",
-                                  "from": "pinkie@>=2.0.0 <3.0.0",
-                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                                  "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                                  "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
                                 }
                               }
                             }
@@ -1059,28 +1492,41 @@
                 },
                 "redent": {
                   "version": "1.0.0",
-                  "from": "redent@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
+                  "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
+                  "requires": {
+                    "indent-string": "^2.1.0",
+                    "strip-indent": "^1.0.1"
+                  },
                   "dependencies": {
                     "indent-string": {
                       "version": "2.1.0",
-                      "from": "indent-string@>=2.1.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
+                      "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
+                      "requires": {
+                        "repeating": "^2.0.0"
+                      },
                       "dependencies": {
                         "repeating": {
                           "version": "2.0.1",
-                          "from": "repeating@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
+                          "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
+                          "requires": {
+                            "is-finite": "^1.0.0"
+                          },
                           "dependencies": {
                             "is-finite": {
                               "version": "1.0.2",
-                              "from": "is-finite@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
+                              "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
+                              "requires": {
+                                "number-is-nan": "^1.0.0"
+                              },
                               "dependencies": {
                                 "number-is-nan": {
                                   "version": "1.0.1",
-                                  "from": "number-is-nan@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz"
+                                  "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+                                  "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
                                 }
                               }
                             }
@@ -1090,15 +1536,18 @@
                     },
                     "strip-indent": {
                       "version": "1.0.1",
-                      "from": "strip-indent@>=1.0.1 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
+                      "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
+                      "requires": {
+                        "get-stdin": "^4.0.1"
+                      }
                     }
                   }
                 },
                 "trim-newlines": {
                   "version": "1.0.0",
-                  "from": "trim-newlines@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
+                  "integrity": "sha1-WIeWa7WCpFA6QetST301ARgVphM="
                 }
               }
             }
@@ -1106,48 +1555,57 @@
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         },
         "winston": {
           "version": "0.8.3",
-          "from": "winston@>=0.8.1 <0.9.0",
           "resolved": "https://registry.npmjs.org/winston/-/winston-0.8.3.tgz",
+          "integrity": "sha1-ZLar9M0Brcrv1QCTk7HY6L7BnbA=",
+          "requires": {
+            "async": "0.2.x",
+            "colors": "0.6.x",
+            "cycle": "1.0.x",
+            "eyes": "0.1.x",
+            "isstream": "0.1.x",
+            "pkginfo": "0.3.x",
+            "stack-trace": "0.0.x"
+          },
           "dependencies": {
             "async": {
               "version": "0.2.10",
-              "from": "async@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.10.tgz",
+              "integrity": "sha1-trvgsGdLnXGXCMo43owjfLUmw9E="
             },
             "colors": {
               "version": "0.6.2",
-              "from": "colors@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz"
+              "resolved": "https://registry.npmjs.org/colors/-/colors-0.6.2.tgz",
+              "integrity": "sha1-JCP+ZnisDF2uiFLl0OW+CMmXq8w="
             },
             "cycle": {
               "version": "1.0.3",
-              "from": "cycle@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/cycle/-/cycle-1.0.3.tgz",
+              "integrity": "sha1-IegLK+hYD5i0aPN5QwZisEbDStI="
             },
             "eyes": {
               "version": "0.1.8",
-              "from": "eyes@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz"
+              "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
+              "integrity": "sha1-Ys8SAjTGg3hdkCNIqADvPgzCC8A="
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.0 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "pkginfo": {
               "version": "0.3.1",
-              "from": "pkginfo@>=0.3.0 <0.4.0",
-              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/pkginfo/-/pkginfo-0.3.1.tgz",
+              "integrity": "sha1-Wyn2qB9wcXFC4J52W76rl7T4HiE="
             },
             "stack-trace": {
               "version": "0.0.9",
-              "from": "stack-trace@>=0.0.0 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz"
+              "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
+              "integrity": "sha1-qPbq7KkGdMMz58Q5U/J1tFFRBpU="
             }
           }
         }
@@ -1155,124 +1613,189 @@
     },
     "fh-forms": {
       "version": "1.16.9",
-      "from": "fh-forms@1.16.9",
       "resolved": "https://registry.npmjs.org/fh-forms/-/fh-forms-1.16.9.tgz",
+      "integrity": "sha1-vMqE9S5phNvnhy7UH40bM2fjqyc=",
+      "requires": {
+        "archiver": "1.2.0",
+        "async": "0.2.9",
+        "fh-cls-mongoose": "2.1.1",
+        "fh-gridfs": "1.1.1",
+        "fh-logger": "0.5.0",
+        "fh-mbaas-client": "1.1.1",
+        "handlebars": "4.0.6",
+        "lodash": "2.2.1",
+        "mime": "1.4.1",
+        "mkdirp": "^0.5.1",
+        "mmmagic": "^0.4.1",
+        "moment": "2.19.3",
+        "mongodb": "2.1.18",
+        "mongodb-uri": "0.9.7",
+        "mongoose": "4.11.14",
+        "mongoose-paginate": "5.0.3",
+        "phantom": "4.0.12",
+        "request": "2.83.0",
+        "underscore": "1.8.0",
+        "yauzl": "2.4.1"
+      },
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk="
         },
         "fh-logger": {
           "version": "0.5.0",
-          "from": "fh-logger@0.5.0",
           "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+          "integrity": "sha1-9S06fBNYYgb6TWMgLAhGDyFLCTI=",
+          "requires": {
+            "bunyan": "^1.5.1",
+            "continuation-local-storage": "^3.1.7",
+            "node-uuid": "^1.4.7"
+          },
           "dependencies": {
             "bunyan": {
               "version": "1.8.1",
-              "from": "bunyan@>=1.5.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+              "integrity": "sha1-aMakpQLVYgvJ9y1nNoEMGxiYCX8=",
+              "requires": {
+                "dtrace-provider": "~0.6",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
+              },
               "dependencies": {
                 "dtrace-provider": {
                   "version": "0.6.0",
-                  "from": "dtrace-provider@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                  "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
                   "optional": true,
+                  "requires": {
+                    "nan": "^2.0.8"
+                  },
                   "dependencies": {
                     "nan": {
                       "version": "2.3.5",
-                      "from": "nan@>=2.0.8 <3.0.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
                       "optional": true
                     }
                   }
                 },
                 "moment": {
                   "version": "2.13.0",
-                  "from": "moment@>=2.10.6 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "resolved": "http://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI=",
                   "optional": true
                 },
                 "mv": {
                   "version": "2.1.1",
-                  "from": "mv@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
                   "optional": true,
+                  "requires": {
+                    "mkdirp": "~0.5.1",
+                    "ncp": "~2.0.0",
+                    "rimraf": "~2.4.0"
+                  },
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                       "optional": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                           "optional": true
                         }
                       }
                     },
                     "ncp": {
                       "version": "2.0.0",
-                      "from": "ncp@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                       "optional": true
                     },
                     "rimraf": {
                       "version": "2.4.5",
-                      "from": "rimraf@>=2.4.0 <2.5.0",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                       "optional": true,
+                      "requires": {
+                        "glob": "^6.0.1"
+                      },
                       "dependencies": {
                         "glob": {
                           "version": "6.0.4",
-                          "from": "glob@>=6.0.1 <7.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                           "optional": true,
+                          "requires": {
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
+                          },
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.5",
-                              "from": "inflight@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                               "optional": true,
+                              "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                                   "optional": true
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                               "optional": true
                             },
                             "minimatch": {
                               "version": "3.0.2",
-                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                              "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
                               "optional": true,
+                              "requires": {
+                                "brace-expansion": "^1.0.0"
+                              },
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.5",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                  "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
                                   "optional": true,
+                                  "requires": {
+                                    "balanced-match": "^0.4.1",
+                                    "concat-map": "0.0.1"
+                                  },
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.1",
-                                      "from": "balanced-match@>=0.4.1 <0.5.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                                       "optional": true
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                       "optional": true
                                     }
                                   }
@@ -1281,20 +1804,23 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
-                              "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                              "requires": {
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                               "optional": true
                             }
                           }
@@ -1305,38 +1831,48 @@
                 },
                 "safe-json-stringify": {
                   "version": "1.0.3",
-                  "from": "safe-json-stringify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                  "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
                   "optional": true
                 }
               }
             },
             "continuation-local-storage": {
               "version": "3.1.7",
-              "from": "continuation-local-storage@>=3.1.7 <4.0.0",
               "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+              "integrity": "sha1-+PfbzS38Zt2gXaDEu1n3yRIMOvY=",
+              "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.0.1"
+              },
               "dependencies": {
                 "async-listener": {
                   "version": "0.6.0",
-                  "from": "async-listener@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+                  "integrity": "sha1-uN4eemhwUcBfKneNAHuivhi7gCM=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 },
                 "emitter-listener": {
                   "version": "1.0.1",
-                  "from": "emitter-listener@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                  "integrity": "sha1-skmepuWCMKUsJo1d8mHuzZ8Q/pc=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 }
@@ -1344,97 +1880,157 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <2.0.0",
-              "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             }
           }
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "lodash": {
           "version": "2.2.1",
-          "from": "lodash@2.2.1",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz",
+          "integrity": "sha1-ypNf0UqzwMhyq6zxmLnNpQFECGc="
         },
         "moment": {
           "version": "2.19.3",
-          "from": "moment@2.19.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
         },
         "mongodb": {
           "version": "2.1.18",
-          "from": "mongodb@2.1.18",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz"
+          "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+          "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.3.18",
+            "readable-stream": "1.0.31"
+          }
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "mongodb-core@1.3.18",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz"
+          "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
+          "requires": {
+            "bson": "~0.4.23",
+            "require_optional": "~1.0.0"
+          }
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "request": {
           "version": "2.83.0",
-          "from": "request@2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz"
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha512-lR3gD69osqm6EYLk9wB/G1W/laGWjzH90t1vEa2xuxHD5KUrSzp9pUSfTm+YC5Nxt2T8nMPEvKlhbQayU7bgFw==",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "underscore": {
           "version": "1.8.0",
-          "from": "underscore@1.8.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz",
+          "integrity": "sha1-60C052lNs+N28vQ5L7Ki+AMGPwE="
         }
       }
     },
     "fh-gridfs": {
       "version": "1.1.1",
-      "from": "fh-gridfs@1.1.1",
       "resolved": "https://registry.npmjs.org/fh-gridfs/-/fh-gridfs-1.1.1.tgz",
+      "integrity": "sha1-pfK1Xvl/2YFXrt6JPlEdnjFYW/U=",
+      "requires": {
+        "archiver": "0.4.9",
+        "async": "0.2.9",
+        "base64-stream": "0.1.2",
+        "gridfs-stream": "0.4.0",
+        "lodash": "2.1.0",
+        "mime": "1.4.1",
+        "mongodb": "2.1.18",
+        "rimraf": "2.2.2",
+        "usage": "^0.7.1"
+      },
       "dependencies": {
         "archiver": {
           "version": "0.4.9",
-          "from": "archiver@0.4.9",
           "resolved": "https://registry.npmjs.org/archiver/-/archiver-0.4.9.tgz",
+          "integrity": "sha1-fIpcjxhkl7QwaYhVsagnr4HOlPE=",
+          "requires": {
+            "iconv-lite": "~0.2.11",
+            "readable-stream": "~1.0.2"
+          },
           "dependencies": {
             "iconv-lite": {
               "version": "0.2.11",
-              "from": "iconv-lite@>=0.2.11 <0.3.0",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz"
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.2.11.tgz",
+              "integrity": "sha1-HOYKOleGSiktEyH/RgnKS7llrcg="
             },
             "readable-stream": {
               "version": "1.0.34",
-              "from": "readable-stream@>=1.0.2 <1.1.0",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+              "integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             }
@@ -1442,70 +2038,86 @@
         },
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk="
         },
         "base64-stream": {
           "version": "0.1.2",
-          "from": "base64-stream@0.1.2",
           "resolved": "https://registry.npmjs.org/base64-stream/-/base64-stream-0.1.2.tgz",
+          "integrity": "sha1-oaeaYYbTUHp/YmCQEgpXx7gohNA=",
+          "requires": {
+            "readable-stream": "1.0.2"
+          },
           "dependencies": {
             "readable-stream": {
               "version": "1.0.2",
-              "from": "readable-stream@1.0.2",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.2.tgz",
+              "integrity": "sha1-ITzjaGT8Hw1OmOA7nrksZAQimdQ="
             }
           }
         },
         "gridfs-stream": {
           "version": "0.4.0",
-          "from": "gridfs-stream@0.4.0",
-          "resolved": "https://registry.npmjs.org/gridfs-stream/-/gridfs-stream-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/gridfs-stream/-/gridfs-stream-0.4.0.tgz",
+          "integrity": "sha1-9295Hg0bImSeEb7qzd+OYr2Jyio="
         },
         "lodash": {
           "version": "2.1.0",
-          "from": "lodash@2.1.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.1.0.tgz",
+          "integrity": "sha1-Bjfqqjaooc/IZcOt+5Qhib+wmY0="
         },
         "mime": {
           "version": "1.4.1",
-          "from": "mime@1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
         },
         "mongodb": {
           "version": "2.1.18",
-          "from": "mongodb@2.1.18",
           "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+          "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.3.18",
+            "readable-stream": "1.0.31"
+          },
           "dependencies": {
             "es6-promise": {
               "version": "3.0.2",
-              "from": "es6-promise@3.0.2",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+              "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
             },
             "mongodb-core": {
               "version": "1.3.18",
-              "from": "mongodb-core@1.3.18",
               "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+              "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
+              "requires": {
+                "bson": "~0.4.23",
+                "require_optional": "~1.0.0"
+              },
               "dependencies": {
                 "bson": {
                   "version": "0.4.23",
-                  "from": "bson@>=0.4.23 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+                  "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+                  "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
                 },
                 "require_optional": {
                   "version": "1.0.1",
-                  "from": "require_optional@>=1.0.0 <1.1.0",
                   "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+                  "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+                  "requires": {
+                    "resolve-from": "^2.0.0",
+                    "semver": "^5.1.0"
+                  },
                   "dependencies": {
                     "resolve-from": {
                       "version": "2.0.0",
-                      "from": "resolve-from@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
                     },
                     "semver": {
                       "version": "5.4.1",
-                      "from": "semver@>=5.1.0 <6.0.0",
-                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                      "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                      "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
                     }
                   }
                 }
@@ -1513,28 +2125,34 @@
             },
             "readable-stream": {
               "version": "1.0.31",
-              "from": "readable-stream@1.0.31",
               "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+              "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+              "requires": {
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "0.0.1",
+                "string_decoder": "~0.10.x"
+              },
               "dependencies": {
                 "core-util-is": {
                   "version": "1.0.2",
-                  "from": "core-util-is@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                  "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                  "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                 },
                 "inherits": {
                   "version": "2.0.3",
-                  "from": "inherits@>=2.0.1 <2.1.0",
-                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                  "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                  "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                 },
                 "isarray": {
                   "version": "0.0.1",
-                  "from": "isarray@0.0.1",
-                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+                  "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                  "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
                 },
                 "string_decoder": {
                   "version": "0.10.31",
-                  "from": "string_decoder@>=0.10.0 <0.11.0",
-                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+                  "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+                  "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
                 }
               }
             }
@@ -1542,31 +2160,38 @@
         },
         "rimraf": {
           "version": "2.2.2",
-          "from": "rimraf@2.2.2",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.2.tgz",
+          "integrity": "sha1-2Z7EHcZG5Vv3p6RKJVwovvM6ir8=",
+          "requires": {
+            "graceful-fs": "~2"
+          },
           "dependencies": {
             "graceful-fs": {
               "version": "2.0.3",
-              "from": "graceful-fs@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz",
+              "integrity": "sha1-fNLNsiiko/Nule+mzBQt59GhNtA=",
               "optional": true
             }
           }
         },
         "usage": {
           "version": "0.7.1",
-          "from": "usage@>=0.7.1 <0.8.0",
           "resolved": "https://registry.npmjs.org/usage/-/usage-0.7.1.tgz",
+          "integrity": "sha1-JfMQalGVUKukG/bnaFvJvVMzYv8=",
+          "requires": {
+            "bindings": "1.x.x",
+            "nan": "^2.0.9"
+          },
           "dependencies": {
             "bindings": {
               "version": "1.3.0",
-              "from": "bindings@>=1.0.0 <2.0.0",
-              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.3.0.tgz",
+              "integrity": "sha1-s0b27PapX1qBXFg5/HzbIlAvHtc="
             },
             "nan": {
               "version": "2.7.0",
-              "from": "nan@>=2.0.9 <3.0.0",
-              "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+              "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY="
             }
           }
         }
@@ -1574,126 +2199,173 @@
     },
     "fh-health": {
       "version": "0.3.3",
-      "from": "fh-health@0.3.3",
       "resolved": "https://registry.npmjs.org/fh-health/-/fh-health-0.3.3.tgz",
+      "integrity": "sha512-DIT/GJL8JyaQWtP+RzqFnAGviCfhxqXmHqzxCBwnJ0vfGwHu2L0YvTeMZSRGE/DdBxE95kyIxzy1pbZjHYPT2A==",
+      "requires": {
+        "async": "0.2.9",
+        "fhlog": "^0.13.1"
+      },
       "dependencies": {
         "async": {
           "version": "0.2.9",
-          "from": "async@0.2.9",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.2.9.tgz",
+          "integrity": "sha1-32MGD789Myhqdqr21Vophtn/hhk="
         }
       }
     },
     "fh-logger": {
       "version": "0.5.2",
-      "from": "fh-logger@0.5.2",
       "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.2.tgz",
+      "integrity": "sha1-514k7651V+hu+X/FqrCv4l0S32E=",
+      "requires": {
+        "bunyan": "^1.5.1",
+        "continuation-local-storage": "^3.1.7",
+        "node-uuid": "^1.4.7"
+      },
       "dependencies": {
         "bunyan": {
           "version": "1.8.1",
-          "from": "bunyan@>=1.5.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+          "integrity": "sha1-aMakpQLVYgvJ9y1nNoEMGxiYCX8=",
+          "requires": {
+            "dtrace-provider": "~0.6",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
+          },
           "dependencies": {
             "dtrace-provider": {
               "version": "0.6.0",
-              "from": "dtrace-provider@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+              "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
               "optional": true,
+              "requires": {
+                "nan": "^2.0.8"
+              },
               "dependencies": {
                 "nan": {
                   "version": "2.3.5",
-                  "from": "nan@>=2.0.8 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                  "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
                   "optional": true
                 }
               }
             },
             "moment": {
               "version": "2.13.0",
-              "from": "moment@>=2.10.6 <3.0.0",
-              "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+              "resolved": "http://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+              "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI=",
               "optional": true
             },
             "mv": {
               "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
+              "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+              },
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
-                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
-                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                       "optional": true
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                  "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                   "optional": true
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
-                  "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
+                  "requires": {
+                    "glob": "^6.0.1"
+                  },
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
+                      "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                      },
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.5",
-                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                          "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                           "optional": true,
+                          "requires": {
+                            "once": "^1.3.0",
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                               "optional": true
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.1",
-                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                           "optional": true
                         },
                         "minimatch": {
                           "version": "3.0.2",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                          "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
                           "optional": true,
+                          "requires": {
+                            "brace-expansion": "^1.0.0"
+                          },
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.5",
-                              "from": "brace-expansion@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                              "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
                               "optional": true,
+                              "requires": {
+                                "balanced-match": "^0.4.1",
+                                "concat-map": "0.0.1"
+                              },
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "0.4.1",
-                                  "from": "balanced-match@>=0.4.1 <0.5.0",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                  "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                                   "optional": true
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                   "optional": true
                                 }
                               }
@@ -1702,20 +2374,23 @@
                         },
                         "once": {
                           "version": "1.3.3",
-                          "from": "once@>=1.3.0 <2.0.0",
-                          "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                          "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                          "requires": {
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.0",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                          "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                           "optional": true
                         }
                       }
@@ -1726,38 +2401,48 @@
             },
             "safe-json-stringify": {
               "version": "1.0.3",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+              "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
               "optional": true
             }
           }
         },
         "continuation-local-storage": {
           "version": "3.1.7",
-          "from": "continuation-local-storage@>=3.1.7 <4.0.0",
           "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+          "integrity": "sha1-+PfbzS38Zt2gXaDEu1n3yRIMOvY=",
+          "requires": {
+            "async-listener": "^0.6.0",
+            "emitter-listener": "^1.0.1"
+          },
           "dependencies": {
             "async-listener": {
               "version": "0.6.0",
-              "from": "async-listener@>=0.6.0 <0.7.0",
               "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+              "integrity": "sha1-uN4eemhwUcBfKneNAHuivhi7gCM=",
+              "requires": {
+                "shimmer": "1.0.0"
+              },
               "dependencies": {
                 "shimmer": {
                   "version": "1.0.0",
-                  "from": "shimmer@1.0.0",
-                  "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                  "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                 }
               }
             },
             "emitter-listener": {
               "version": "1.0.1",
-              "from": "emitter-listener@>=1.0.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+              "integrity": "sha1-skmepuWCMKUsJo1d8mHuzZ8Q/pc=",
+              "requires": {
+                "shimmer": "1.0.0"
+              },
               "dependencies": {
                 "shimmer": {
                   "version": "1.0.0",
-                  "from": "shimmer@1.0.0",
-                  "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                  "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                 }
               }
             }
@@ -1765,126 +2450,174 @@
         },
         "node-uuid": {
           "version": "1.4.7",
-          "from": "node-uuid@>=1.4.7 <2.0.0",
-          "resolved": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+          "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+          "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
         }
       }
     },
     "fh-mbaas-client": {
       "version": "1.1.1",
-      "from": "fh-mbaas-client@1.1.1",
       "resolved": "https://registry.npmjs.org/fh-mbaas-client/-/fh-mbaas-client-1.1.1.tgz",
+      "integrity": "sha1-RWU5G/SjWPisCFwZ494atP8J1qI=",
+      "requires": {
+        "fh-logger": "0.5.0",
+        "request": "^2.81.0",
+        "underscore": "^1.8.0"
+      },
       "dependencies": {
         "fh-logger": {
           "version": "0.5.0",
-          "from": "fh-logger@0.5.0",
           "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+          "integrity": "sha1-9S06fBNYYgb6TWMgLAhGDyFLCTI=",
+          "requires": {
+            "bunyan": "^1.5.1",
+            "continuation-local-storage": "^3.1.7",
+            "node-uuid": "^1.4.7"
+          },
           "dependencies": {
             "bunyan": {
               "version": "1.8.1",
-              "from": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+              "integrity": "sha1-aMakpQLVYgvJ9y1nNoEMGxiYCX8=",
+              "requires": {
+                "dtrace-provider": "~0.6",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
+              },
               "dependencies": {
                 "dtrace-provider": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                  "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
                   "optional": true,
+                  "requires": {
+                    "nan": "^2.0.8"
+                  },
                   "dependencies": {
                     "nan": {
                       "version": "2.3.5",
-                      "from": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
                       "optional": true
                     }
                   }
                 },
                 "moment": {
                   "version": "2.13.0",
-                  "from": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI=",
                   "optional": true
                 },
                 "mv": {
                   "version": "2.1.1",
-                  "from": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
                   "optional": true,
+                  "requires": {
+                    "mkdirp": "~0.5.1",
+                    "ncp": "~2.0.0",
+                    "rimraf": "~2.4.0"
+                  },
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                       "optional": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                           "optional": true
                         }
                       }
                     },
                     "ncp": {
                       "version": "2.0.0",
-                      "from": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                       "optional": true
                     },
                     "rimraf": {
                       "version": "2.4.5",
-                      "from": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                       "optional": true,
+                      "requires": {
+                        "glob": "^6.0.1"
+                      },
                       "dependencies": {
                         "glob": {
                           "version": "6.0.4",
-                          "from": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                           "optional": true,
+                          "requires": {
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
+                          },
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.5",
-                              "from": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                               "optional": true,
+                              "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                                   "optional": true
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                               "optional": true
                             },
                             "minimatch": {
                               "version": "3.0.2",
-                              "from": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                              "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
                               "optional": true,
+                              "requires": {
+                                "brace-expansion": "^1.0.0"
+                              },
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.5",
-                                  "from": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                  "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
                                   "optional": true,
+                                  "requires": {
+                                    "balanced-match": "^0.4.1",
+                                    "concat-map": "0.0.1"
+                                  },
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.1",
-                                      "from": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                                       "optional": true
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                       "optional": true
                                     }
                                   }
@@ -1893,20 +2626,23 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                              "requires": {
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                               "optional": true
                             }
                           }
@@ -1917,38 +2653,48 @@
                 },
                 "safe-json-stringify": {
                   "version": "1.0.3",
-                  "from": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
                   "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                  "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
                   "optional": true
                 }
               }
             },
             "continuation-local-storage": {
               "version": "3.1.7",
-              "from": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
               "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+              "integrity": "sha1-+PfbzS38Zt2gXaDEu1n3yRIMOvY=",
+              "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.0.1"
+              },
               "dependencies": {
                 "async-listener": {
                   "version": "0.6.0",
-                  "from": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
                   "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+                  "integrity": "sha1-uN4eemhwUcBfKneNAHuivhi7gCM=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 },
                 "emitter-listener": {
                   "version": "1.0.1",
-                  "from": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
                   "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                  "integrity": "sha1-skmepuWCMKUsJo1d8mHuzZ8Q/pc=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 }
@@ -1956,89 +2702,132 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "http://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             }
           }
         },
         "request": {
           "version": "2.81.0",
-          "from": "request@>=2.81.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.81.0.tgz",
+          "integrity": "sha1-xpKJRqDgbF+Nb4qTM0af/aRimKA=",
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~4.2.1",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "oauth-sign": "~0.8.1",
+            "performance-now": "^0.2.0",
+            "qs": "~6.4.0",
+            "safe-buffer": "^5.0.1",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.0.0"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
             },
             "aws4": {
               "version": "1.6.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+              "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
             },
             "caseless": {
               "version": "0.12.0",
-              "from": "caseless@>=0.12.0 <0.13.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+              "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
             },
             "form-data": {
               "version": "2.1.2",
-              "from": "form-data@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 }
               }
             },
             "har-validator": {
               "version": "4.2.1",
-              "from": "har-validator@>=4.2.1 <4.3.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-4.2.1.tgz",
+              "integrity": "sha1-M0gdDxu/9gDdID11gSpqX7oALio=",
+              "requires": {
+                "ajv": "^4.9.1",
+                "har-schema": "^1.0.5"
+              },
               "dependencies": {
                 "ajv": {
                   "version": "4.11.5",
-                  "from": "ajv@>=4.9.1 <5.0.0",
                   "resolved": "https://registry.npmjs.org/ajv/-/ajv-4.11.5.tgz",
+                  "integrity": "sha1-tu50ZXuZOgHc5Et5RNVvSFgo1b0=",
+                  "requires": {
+                    "co": "^4.6.0",
+                    "json-stable-stringify": "^1.0.1"
+                  },
                   "dependencies": {
                     "co": {
                       "version": "4.6.0",
-                      "from": "co@>=4.6.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+                      "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+                      "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
                     },
                     "json-stable-stringify": {
                       "version": "1.0.1",
-                      "from": "json-stable-stringify@>=1.0.1 <2.0.0",
                       "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-1.0.1.tgz",
+                      "integrity": "sha1-mnWdOcXy/1A/1TAGRu1EX4jE+a8=",
+                      "requires": {
+                        "jsonify": "~0.0.0"
+                      },
                       "dependencies": {
                         "jsonify": {
                           "version": "0.0.0",
-                          "from": "jsonify@>=0.0.0 <0.1.0",
-                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/jsonify/-/jsonify-0.0.0.tgz",
+                          "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM="
                         }
                       }
                     }
@@ -2046,123 +2835,177 @@
                 },
                 "har-schema": {
                   "version": "1.0.5",
-                  "from": "har-schema@>=1.0.5 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-1.0.5.tgz",
+                  "integrity": "sha1-0mMTX0MwfALGAq/I/pWXDAFRNp4="
                 }
               }
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "requires": {
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
+              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.x.x"
+                  }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "requires": {
+                    "boom": "2.x.x"
+                  }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "requires": {
+                    "hoek": "2.x.x"
+                  }
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "requires": {
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                 },
                 "jsprim": {
                   "version": "1.3.1",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.11.0",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.11.0.tgz",
+                  "integrity": "sha1-LY1eu0pvqyj/ujf6YqkPSj6lnXc=",
+                  "requires": {
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jodid25519": "^1.0.0",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.1",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-                      "optional": true
+                      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "^0.14.3"
+                      }
                     },
                     "dashdash": {
                       "version": "1.14.1",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+                      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+                      "requires": {
+                        "assert-plus": "^1.0.0"
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "optional": true
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "~0.1.0"
+                      }
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "requires": {
+                        "assert-plus": "^1.0.0"
+                      }
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "optional": true
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "~0.1.0"
+                      }
                     },
                     "jsbn": {
                       "version": "0.1.1",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+                      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.5",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+                      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
                       "optional": true
                     }
                   }
@@ -2171,392 +3014,532 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
             },
             "mime-types": {
               "version": "2.1.14",
-              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.14.tgz",
+              "integrity": "sha1-9+99l1g/yvO30oK2+LVnnaselO4=",
+              "requires": {
+                "mime-db": "~1.26.0"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.26.0",
-                  "from": "mime-db@>=1.26.0 <1.27.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.26.0.tgz",
+                  "integrity": "sha1-6v/NDk/Gk1z4E02iRuLmw1MFrf8="
                 }
               }
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
             },
             "performance-now": {
               "version": "0.2.0",
-              "from": "performance-now@>=0.2.0 <0.3.0",
-              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-0.2.0.tgz",
+              "integrity": "sha1-M+8wxcd9TqIcWlOGnZG1bY8lVeU="
             },
             "qs": {
               "version": "6.4.0",
-              "from": "qs@>=6.4.0 <6.5.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.4.0.tgz",
+              "integrity": "sha1-E+JtKK1rD/qpExLNO/cI7TUecjM="
             },
             "safe-buffer": {
               "version": "5.0.1",
-              "from": "safe-buffer@>=5.0.1 <6.0.0",
-              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.0.1.tgz",
+              "integrity": "sha1-0mPKVGls2KMGtcplUekt5XkY++c="
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "requires": {
+                "punycode": "^1.4.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.6.0",
-              "from": "tunnel-agent@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+              "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+              "requires": {
+                "safe-buffer": "^5.0.1"
+              }
             },
             "uuid": {
               "version": "3.0.1",
-              "from": "uuid@>=3.0.0 <4.0.0",
-              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.0.1.tgz",
+              "integrity": "sha1-ZUS7ot/ajBzxfmKaOjBeK7H+5sE="
             }
           }
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@>=1.8.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         }
       }
     },
     "fh-mbaas-middleware": {
       "version": "2.3.2",
-      "from": "fh-mbaas-middleware@2.3.2",
       "resolved": "https://registry.npmjs.org/fh-mbaas-middleware/-/fh-mbaas-middleware-2.3.2.tgz",
+      "integrity": "sha1-tzp/7bIUNrwEbrYc5UT2ML0HFeA=",
+      "requires": {
+        "async": "0.9.2",
+        "cuid": "1.3.8",
+        "express": "4.16.0",
+        "fh-amqp-js": "0.7.1",
+        "fh-cls-mongoose": "2.1.1",
+        "fh-logger": "0.5.0",
+        "moment": "2.19.3",
+        "mongodb": "2.1.18",
+        "mongoose": "4.11.14",
+        "mongoose-filter-denormalize": "0.2.1",
+        "mongoose-timestamp": "0.3.0",
+        "mongoose-unique-validator": "0.3.0",
+        "mongoose-validator": "1.2.5",
+        "nodemailer": "2.6.4",
+        "nodemailer-sendgrid-transport": "0.2.0",
+        "optimist": "0.6.1",
+        "rc": "0.4.0",
+        "redis": "0.8.2",
+        "request": "2.83.0",
+        "underscore": "1.8.3"
+      },
       "dependencies": {
         "accepts": {
           "version": "1.3.4",
-          "from": "accepts@>=1.3.4 <1.4.0",
-          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz"
+          "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.4.tgz",
+          "integrity": "sha1-hiRnWMfdbSGmR0/whKR0DsBesh8=",
+          "requires": {
+            "mime-types": "~2.1.16",
+            "negotiator": "0.6.1"
+          }
         },
         "addressparser": {
           "version": "1.0.1",
-          "from": "addressparser@1.0.1",
-          "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/addressparser/-/addressparser-1.0.1.tgz",
+          "integrity": "sha1-R6++GiqSYhkdtoOOT9HTm0CCF0Y="
         },
         "ajv": {
           "version": "5.5.1",
-          "from": "ajv@>=5.1.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
         },
         "array-flatten": {
           "version": "1.1.1",
-          "from": "array-flatten@1.1.1",
-          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+          "integrity": "sha1-ml9pkFGx5wczKPKgCJaLZOopVdI="
         },
         "asn1": {
           "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "async": {
           "version": "0.9.2",
-          "from": "async@0.9.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "asynckit": {
           "version": "0.4.0",
-          "from": "asynckit@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "from": "aws-sign2@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "aws4@>=1.6.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "optional": true
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
         },
         "bluebird": {
           "version": "3.5.1",
-          "from": "bluebird@>=3.5.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+          "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
         },
         "body-parser": {
           "version": "1.18.2",
-          "from": "body-parser@1.18.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz"
+          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
+          "integrity": "sha1-h2eKGdhLR9hZuDGZvVm84iKxBFQ=",
+          "requires": {
+            "bytes": "3.0.0",
+            "content-type": "~1.0.4",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "http-errors": "~1.6.2",
+            "iconv-lite": "0.4.19",
+            "on-finished": "~2.3.0",
+            "qs": "6.5.1",
+            "raw-body": "2.3.2",
+            "type-is": "~1.6.15"
+          }
         },
         "boom": {
           "version": "4.3.1",
-          "from": "boom@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
         },
         "browser-fingerprint": {
           "version": "0.0.1",
-          "from": "browser-fingerprint@0.0.1",
-          "resolved": "https://registry.npmjs.org/browser-fingerprint/-/browser-fingerprint-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/browser-fingerprint/-/browser-fingerprint-0.0.1.tgz",
+          "integrity": "sha1-jfPNyiW/fVs1QtYVRdcwBT/OYEo="
         },
         "bson": {
           "version": "0.4.23",
-          "from": "bson@>=0.4.23 <0.5.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz"
+          "resolved": "https://registry.npmjs.org/bson/-/bson-0.4.23.tgz",
+          "integrity": "sha1-5louPHUH/63kEJvHV1p25Q+NqRU="
         },
         "buffer-shims": {
           "version": "1.0.0",
-          "from": "buffer-shims@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+          "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
         },
         "buildmail": {
           "version": "3.10.0",
-          "from": "buildmail@3.10.0",
-          "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-3.10.0.tgz"
+          "resolved": "https://registry.npmjs.org/buildmail/-/buildmail-3.10.0.tgz",
+          "integrity": "sha1-xoJtcW55RbtvaxQ0tTmF4CmgMVk=",
+          "requires": {
+            "addressparser": "1.0.1",
+            "libbase64": "0.1.0",
+            "libmime": "2.1.0",
+            "libqp": "1.1.0",
+            "nodemailer-fetch": "1.6.0",
+            "nodemailer-shared": "1.1.0"
+          }
         },
         "bytes": {
           "version": "3.0.0",
-          "from": "bytes@3.0.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz",
+          "integrity": "sha1-0ygVQE1olpn4Wk6k+odV3ROpYEg="
         },
         "caseless": {
           "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "co": {
           "version": "4.6.0",
-          "from": "co@>=4.6.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
         },
         "content-disposition": {
           "version": "0.5.2",
-          "from": "content-disposition@0.5.2",
-          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz"
+          "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.2.tgz",
+          "integrity": "sha1-DPaLud318r55YcOoUXjLhdunjLQ="
         },
         "content-type": {
           "version": "1.0.4",
-          "from": "content-type@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
+          "integrity": "sha1-4TjMdeBAxyexlm/l5fjJruJW/js="
         },
         "cookie": {
           "version": "0.3.1",
-          "from": "cookie@0.3.1",
-          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
+          "integrity": "sha1-5+Ch+e9DtMi6klxcWpboBtFoc7s="
         },
         "cookie-signature": {
           "version": "1.0.6",
-          "from": "cookie-signature@1.0.6",
-          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz"
+          "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+          "integrity": "sha1-4wOogrNCzD7oylE6eZmXNNqzriw="
         },
         "core-js": {
           "version": "1.2.7",
-          "from": "core-js@>=1.1.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz"
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
         },
         "core-util-is": {
           "version": "1.0.2",
-          "from": "core-util-is@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cryptiles": {
           "version": "3.1.2",
-          "from": "cryptiles@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.x.x"
+          },
           "dependencies": {
             "boom": {
               "version": "5.2.0",
-              "from": "boom@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
             }
           }
         },
         "cuid": {
           "version": "1.3.8",
-          "from": "cuid@1.3.8",
-          "resolved": "https://registry.npmjs.org/cuid/-/cuid-1.3.8.tgz"
+          "resolved": "https://registry.npmjs.org/cuid/-/cuid-1.3.8.tgz",
+          "integrity": "sha1-S4deCWm612T37AcGz0T1+wgx9rc=",
+          "requires": {
+            "browser-fingerprint": "0.0.1",
+            "core-js": "^1.1.1",
+            "node-fingerprint": "0.0.2"
+          }
         },
         "dashdash": {
           "version": "1.14.1",
-          "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
         },
         "debug": {
           "version": "2.6.9",
-          "from": "debug@2.6.9",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+          "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+          "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+          "requires": {
+            "ms": "2.0.0"
+          }
         },
         "deep-extend": {
           "version": "0.2.11",
-          "from": "deep-extend@>=0.2.5 <0.3.0",
-          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+          "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+          "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "depd": {
           "version": "1.1.1",
-          "from": "depd@>=1.1.1 <1.2.0",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         },
         "destroy": {
           "version": "1.0.4",
-          "from": "destroy@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz"
+          "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.0.4.tgz",
+          "integrity": "sha1-l4hXRCxEdJ5CBmE+N5RiBYJqvYA="
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
         },
         "ee-first": {
           "version": "1.1.1",
-          "from": "ee-first@1.1.1",
-          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+          "integrity": "sha1-WQxhFWsK4vTwJVcyoViyZrxWsh0="
         },
         "encodeurl": {
           "version": "1.0.1",
-          "from": "encodeurl@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
+          "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA="
         },
         "es6-promise": {
           "version": "3.0.2",
-          "from": "es6-promise@3.0.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.0.2.tgz",
+          "integrity": "sha1-AQ1YWEI6XxGJeWZfRkhqlcbuK7Y="
         },
         "escape-html": {
           "version": "1.0.3",
-          "from": "escape-html@>=1.0.3 <1.1.0",
-          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+          "integrity": "sha1-Aljq5NPQwJdN4cFpGI7wBR0dGYg="
         },
         "etag": {
           "version": "1.8.1",
-          "from": "etag@>=1.8.1 <1.9.0",
-          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz"
+          "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+          "integrity": "sha1-Qa4u62XvpiJorr/qg6x9eSmbCIc="
         },
         "express": {
           "version": "4.16.0",
-          "from": "express@4.16.0",
-          "resolved": "https://registry.npmjs.org/express/-/express-4.16.0.tgz"
+          "resolved": "https://registry.npmjs.org/express/-/express-4.16.0.tgz",
+          "integrity": "sha1-tRljjk61jnF4yBtJjvIveYyy4lU=",
+          "requires": {
+            "accepts": "~1.3.4",
+            "array-flatten": "1.1.1",
+            "body-parser": "1.18.2",
+            "content-disposition": "0.5.2",
+            "content-type": "~1.0.4",
+            "cookie": "0.3.1",
+            "cookie-signature": "1.0.6",
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "finalhandler": "1.1.0",
+            "fresh": "0.5.2",
+            "merge-descriptors": "1.0.1",
+            "methods": "~1.1.2",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "path-to-regexp": "0.1.7",
+            "proxy-addr": "~2.0.2",
+            "qs": "6.5.1",
+            "range-parser": "~1.2.0",
+            "safe-buffer": "5.1.1",
+            "send": "0.16.0",
+            "serve-static": "1.13.0",
+            "setprototypeof": "1.1.0",
+            "statuses": "~1.3.1",
+            "type-is": "~1.6.15",
+            "utils-merge": "1.0.1",
+            "vary": "~1.1.2"
+          }
         },
         "extend": {
           "version": "3.0.1",
-          "from": "extend@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "extsprintf": {
           "version": "1.3.0",
-          "from": "extsprintf@1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
           "version": "1.0.0",
-          "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "fh-amqp-js": {
           "version": "0.7.1",
-          "from": "fh-amqp-js@0.7.1",
           "resolved": "https://registry.npmjs.org/fh-amqp-js/-/fh-amqp-js-0.7.1.tgz",
+          "integrity": "sha1-2g1TGdtzw5m5W1rCQnNfZMB2Clk=",
+          "requires": {
+            "amqp": "0.2.0",
+            "async": "0.2.7",
+            "lodash": "2.4.1",
+            "node-uuid": "^1.4.4",
+            "rc": "0.1.1"
+          },
           "dependencies": {
             "amqp": {
               "version": "0.2.0",
-              "from": "amqp@0.2.0",
               "resolved": "https://registry.npmjs.org/amqp/-/amqp-0.2.0.tgz",
+              "integrity": "sha1-yu09Wh719BlmP4Dc9ulTEuX8oso=",
+              "requires": {
+                "lodash": "~1.3.1"
+              },
               "dependencies": {
                 "lodash": {
                   "version": "1.3.1",
-                  "from": "lodash@>=1.3.1 <1.4.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-1.3.1.tgz",
+                  "integrity": "sha1-pGY7U2hriV/wdOK6UE37dqjit3A="
                 }
               }
             },
             "async": {
               "version": "0.2.7",
-              "from": "async@0.2.7",
-              "resolved": "https://registry.npmjs.org/async/-/async-0.2.7.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-0.2.7.tgz",
+              "integrity": "sha1-RMXuFRrs5sS/U2TPx8KP5OWPGN8="
             },
             "lodash": {
               "version": "2.4.1",
-              "from": "lodash@2.4.1",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.1.tgz",
+              "integrity": "sha1-W3cjA03aTSYuWkb7LFjXzCL3FCA="
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.4 <2.0.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             },
             "rc": {
               "version": "0.1.1",
-              "from": "rc@0.1.1",
               "resolved": "https://registry.npmjs.org/rc/-/rc-0.1.1.tgz",
+              "integrity": "sha1-Wj/FnKC1wAoHjhoQq6kou27e+wQ=",
+              "requires": {
+                "deep-extend": "~0.2.5",
+                "ini": "~1.1.0",
+                "optimist": "~0.3.4"
+              },
               "dependencies": {
                 "deep-extend": {
                   "version": "0.2.11",
-                  "from": "deep-extend@>=0.2.5 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz"
+                  "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.2.11.tgz",
+                  "integrity": "sha1-eha6aXKRMjQFBhcElLyD9wdv4I8="
                 },
                 "ini": {
                   "version": "1.1.0",
-                  "from": "ini@>=1.1.0 <1.2.0",
-                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+                  "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+                  "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE="
                 },
                 "optimist": {
                   "version": "0.3.7",
-                  "from": "optimist@>=0.3.4 <0.4.0",
                   "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.3.7.tgz",
+                  "integrity": "sha1-yQlBrVnkJzMokjB00s8ufLxuwNk=",
+                  "requires": {
+                    "wordwrap": "~0.0.2"
+                  },
                   "dependencies": {
                     "wordwrap": {
                       "version": "0.0.3",
-                      "from": "wordwrap@>=0.0.2 <0.1.0",
-                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+                      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
                     }
                   }
                 }
@@ -2566,119 +3549,165 @@
         },
         "fh-cls-mongoose": {
           "version": "2.1.1",
-          "from": "fh-cls-mongoose@2.1.1",
-          "resolved": "https://registry.npmjs.org/fh-cls-mongoose/-/fh-cls-mongoose-2.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/fh-cls-mongoose/-/fh-cls-mongoose-2.1.1.tgz",
+          "integrity": "sha1-JMzjgwR6or1KayKpZh8c71ldCJQ=",
+          "requires": {
+            "shimmer": "^1"
+          }
         },
         "fh-logger": {
           "version": "0.5.0",
-          "from": "fh-logger@0.5.0",
           "resolved": "https://registry.npmjs.org/fh-logger/-/fh-logger-0.5.0.tgz",
+          "integrity": "sha1-9S06fBNYYgb6TWMgLAhGDyFLCTI=",
+          "requires": {
+            "bunyan": "^1.5.1",
+            "continuation-local-storage": "^3.1.7",
+            "node-uuid": "^1.4.7"
+          },
           "dependencies": {
             "bunyan": {
               "version": "1.8.1",
-              "from": "bunyan@>=1.5.1 <2.0.0",
               "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.1.tgz",
+              "integrity": "sha1-aMakpQLVYgvJ9y1nNoEMGxiYCX8=",
+              "requires": {
+                "dtrace-provider": "~0.6",
+                "moment": "^2.10.6",
+                "mv": "~2",
+                "safe-json-stringify": "~1"
+              },
               "dependencies": {
                 "dtrace-provider": {
                   "version": "0.6.0",
-                  "from": "dtrace-provider@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.6.0.tgz",
+                  "integrity": "sha1-CweNVReTfYcxAUUtkUZzdVe3XlE=",
                   "optional": true,
+                  "requires": {
+                    "nan": "^2.0.8"
+                  },
                   "dependencies": {
                     "nan": {
                       "version": "2.3.5",
-                      "from": "nan@>=2.0.8 <3.0.0",
                       "resolved": "https://registry.npmjs.org/nan/-/nan-2.3.5.tgz",
+                      "integrity": "sha1-gioNwmYpDOTNOhIoLKPn42Rmigg=",
                       "optional": true
                     }
                   }
                 },
                 "moment": {
                   "version": "2.13.0",
-                  "from": "moment@>=2.10.6 <3.0.0",
                   "resolved": "https://registry.npmjs.org/moment/-/moment-2.13.0.tgz",
+                  "integrity": "sha1-JBYtmVIebUD5muaTnoBtITnqrFI=",
                   "optional": true
                 },
                 "mv": {
                   "version": "2.1.1",
-                  "from": "mv@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+                  "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
                   "optional": true,
+                  "requires": {
+                    "mkdirp": "~0.5.1",
+                    "ncp": "~2.0.0",
+                    "rimraf": "~2.4.0"
+                  },
                   "dependencies": {
                     "mkdirp": {
                       "version": "0.5.1",
-                      "from": "mkdirp@>=0.5.1 <0.6.0",
                       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                       "optional": true,
+                      "requires": {
+                        "minimist": "0.0.8"
+                      },
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
-                          "from": "minimist@0.0.8",
                           "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                           "optional": true
                         }
                       }
                     },
                     "ncp": {
                       "version": "2.0.0",
-                      "from": "ncp@>=2.0.0 <2.1.0",
                       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                       "optional": true
                     },
                     "rimraf": {
                       "version": "2.4.5",
-                      "from": "rimraf@>=2.4.0 <2.5.0",
                       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                       "optional": true,
+                      "requires": {
+                        "glob": "^6.0.1"
+                      },
                       "dependencies": {
                         "glob": {
                           "version": "6.0.4",
-                          "from": "glob@>=6.0.1 <7.0.0",
                           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                           "optional": true,
+                          "requires": {
+                            "inflight": "^1.0.4",
+                            "inherits": "2",
+                            "minimatch": "2 || 3",
+                            "once": "^1.3.0",
+                            "path-is-absolute": "^1.0.0"
+                          },
                           "dependencies": {
                             "inflight": {
                               "version": "1.0.5",
-                              "from": "inflight@>=1.0.4 <2.0.0",
                               "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.5.tgz",
+                              "integrity": "sha1-2zIEzVqd4ubNiQuFxuL2a89PYgo=",
                               "optional": true,
+                              "requires": {
+                                "once": "^1.3.0",
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                                   "optional": true
                                 }
                               }
                             },
                             "inherits": {
                               "version": "2.0.1",
-                              "from": "inherits@>=2.0.0 <3.0.0",
                               "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+                              "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
                               "optional": true
                             },
                             "minimatch": {
                               "version": "3.0.2",
-                              "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                               "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.2.tgz",
+                              "integrity": "sha1-DzmKcwDqRB6cNIyD2Yq4ydv5xAo=",
                               "optional": true,
+                              "requires": {
+                                "brace-expansion": "^1.0.0"
+                              },
                               "dependencies": {
                                 "brace-expansion": {
                                   "version": "1.1.5",
-                                  "from": "brace-expansion@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.5.tgz",
+                                  "integrity": "sha1-9bStV04st8zB64Pm/nm47K33pSY=",
                                   "optional": true,
+                                  "requires": {
+                                    "balanced-match": "^0.4.1",
+                                    "concat-map": "0.0.1"
+                                  },
                                   "dependencies": {
                                     "balanced-match": {
                                       "version": "0.4.1",
-                                      "from": "balanced-match@>=0.4.1 <0.5.0",
                                       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.1.tgz",
+                                      "integrity": "sha1-GQU+LgdI6ts3nabAnUVc9eEDkzU=",
                                       "optional": true
                                     },
                                     "concat-map": {
                                       "version": "0.0.1",
-                                      "from": "concat-map@0.0.1",
                                       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                       "optional": true
                                     }
                                   }
@@ -2687,20 +3716,23 @@
                             },
                             "once": {
                               "version": "1.3.3",
-                              "from": "once@>=1.3.0 <2.0.0",
                               "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "integrity": "sha1-suJhVXzkwxTsgwTz+oJmPkKXyiA=",
+                              "requires": {
+                                "wrappy": "1"
+                              },
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
-                                  "from": "wrappy@>=1.0.0 <2.0.0",
-                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                                  "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                                  "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                                 }
                               }
                             },
                             "path-is-absolute": {
                               "version": "1.0.0",
-                              "from": "path-is-absolute@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.0.tgz",
+                              "integrity": "sha1-Jj2tpmqz8vsQv3+dJN2PPlcO+RI=",
                               "optional": true
                             }
                           }
@@ -2711,38 +3743,48 @@
                 },
                 "safe-json-stringify": {
                   "version": "1.0.3",
-                  "from": "safe-json-stringify@>=1.0.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.3.tgz",
+                  "integrity": "sha1-PLZxdmCghtB8tb2bemh1vPZ70F4=",
                   "optional": true
                 }
               }
             },
             "continuation-local-storage": {
               "version": "3.1.7",
-              "from": "continuation-local-storage@>=3.1.7 <4.0.0",
               "resolved": "https://registry.npmjs.org/continuation-local-storage/-/continuation-local-storage-3.1.7.tgz",
+              "integrity": "sha1-+PfbzS38Zt2gXaDEu1n3yRIMOvY=",
+              "requires": {
+                "async-listener": "^0.6.0",
+                "emitter-listener": "^1.0.1"
+              },
               "dependencies": {
                 "async-listener": {
                   "version": "0.6.0",
-                  "from": "async-listener@>=0.6.0 <0.7.0",
                   "resolved": "https://registry.npmjs.org/async-listener/-/async-listener-0.6.0.tgz",
+                  "integrity": "sha1-uN4eemhwUcBfKneNAHuivhi7gCM=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 },
                 "emitter-listener": {
                   "version": "1.0.1",
-                  "from": "emitter-listener@>=1.0.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/emitter-listener/-/emitter-listener-1.0.1.tgz",
+                  "integrity": "sha1-skmepuWCMKUsJo1d8mHuzZ8Q/pc=",
+                  "requires": {
+                    "shimmer": "1.0.0"
+                  },
                   "dependencies": {
                     "shimmer": {
                       "version": "1.0.0",
-                      "from": "shimmer@1.0.0",
-                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.0.0.tgz",
+                      "integrity": "sha1-ScLXHGeDYLgCvhiyeDgtHLuAXDk="
                     }
                   }
                 }
@@ -2750,904 +3792,1263 @@
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <2.0.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             }
           }
         },
         "finalhandler": {
           "version": "1.1.0",
-          "from": "finalhandler@1.1.0",
-          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.0.tgz",
+          "integrity": "sha1-zgtoVbRYU+eRsvzGgARtiCU91/U=",
+          "requires": {
+            "debug": "2.6.9",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "on-finished": "~2.3.0",
+            "parseurl": "~1.3.2",
+            "statuses": "~1.3.1",
+            "unpipe": "~1.0.0"
+          }
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.1",
-          "from": "form-data@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "forwarded": {
           "version": "0.1.2",
-          "from": "forwarded@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+          "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
         },
         "fresh": {
           "version": "0.5.2",
-          "from": "fresh@0.5.2",
-          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
+          "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+          "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
         },
         "getpass": {
           "version": "0.1.7",
-          "from": "getpass@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
         },
         "har-schema": {
           "version": "2.0.0",
-          "from": "har-schema@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
           "version": "5.0.3",
-          "from": "har-validator@>=5.0.3 <5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
         },
         "hawk": {
           "version": "6.0.2",
-          "from": "hawk@>=6.0.2 <6.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+          "requires": {
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
+          }
         },
         "hoek": {
           "version": "4.2.0",
-          "from": "hoek@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
         },
         "hooks": {
           "version": "0.2.1",
-          "from": "hooks@0.2.1",
-          "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/hooks/-/hooks-0.2.1.tgz",
+          "integrity": "sha1-D1kbGzRL3LPfWXc/Yvu6+Fv0Aos="
         },
         "hooks-fixed": {
           "version": "2.0.0",
-          "from": "hooks-fixed@2.0.0",
-          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+          "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
         },
         "http-errors": {
           "version": "1.6.2",
-          "from": "http-errors@>=1.6.2 <1.7.0",
           "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          },
           "dependencies": {
             "setprototypeof": {
               "version": "1.0.3",
-              "from": "setprototypeof@1.0.3",
-              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+              "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
             }
           }
         },
         "http-signature": {
           "version": "1.2.0",
-          "from": "http-signature@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "httpntlm": {
           "version": "1.6.1",
-          "from": "httpntlm@1.6.1",
           "resolved": "https://registry.npmjs.org/httpntlm/-/httpntlm-1.6.1.tgz",
+          "integrity": "sha1-rQFScUOi6Hc8+uapb1hla7UqNLI=",
+          "requires": {
+            "httpreq": ">=0.4.22",
+            "underscore": "~1.7.0"
+          },
           "dependencies": {
             "underscore": {
               "version": "1.7.0",
-              "from": "underscore@>=1.7.0 <1.8.0",
-              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz"
+              "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.7.0.tgz",
+              "integrity": "sha1-a7rwh3UA02vjTsqlhODbn+8DUgk="
             }
           }
         },
         "httpreq": {
           "version": "0.4.24",
-          "from": "httpreq@>=0.4.22",
-          "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz"
+          "resolved": "https://registry.npmjs.org/httpreq/-/httpreq-0.4.24.tgz",
+          "integrity": "sha1-QzX/2CzZaWaKOUZckprGHWOTYn8="
         },
         "iconv-lite": {
           "version": "0.4.19",
-          "from": "iconv-lite@0.4.19",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+          "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
         },
         "inherits": {
           "version": "2.0.3",
-          "from": "inherits@2.0.3",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
         },
         "ini": {
           "version": "1.1.0",
-          "from": "ini@>=1.1.0 <1.2.0",
-          "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/ini/-/ini-1.1.0.tgz",
+          "integrity": "sha1-ToCMLOFExsF4iRjgNNZ5e8bPYoE="
         },
         "ip": {
           "version": "1.1.5",
-          "from": "ip@>=1.1.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz"
+          "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+          "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
         },
         "ipaddr.js": {
           "version": "1.5.2",
-          "from": "ipaddr.js@1.5.2",
-          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz"
+          "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.5.2.tgz",
+          "integrity": "sha1-1LUFvemUaYfM8PxY2QEP+WB+P6A="
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isarray": {
           "version": "0.0.1",
-          "from": "isarray@0.0.1",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+          "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jsbn": {
           "version": "0.1.1",
-          "from": "jsbn@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "from": "json-schema@0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "from": "json-schema-traverse@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsprim": {
           "version": "1.4.1",
-          "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
         },
         "kareem": {
           "version": "1.5.0",
-          "from": "kareem@1.5.0",
-          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
+          "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+          "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
         },
         "kerberos": {
           "version": "0.0.3",
-          "from": "kerberos@0.0.3",
           "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-0.0.3.tgz",
+          "integrity": "sha1-QoXZKgdI2yeEBi9a3OyfWVbLgYo=",
           "optional": true
         },
         "libbase64": {
           "version": "0.1.0",
-          "from": "libbase64@0.1.0",
-          "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/libbase64/-/libbase64-0.1.0.tgz",
+          "integrity": "sha1-YjUag5VjrF/1vSbxL2Dpgwu3UeY="
         },
         "libmime": {
           "version": "2.1.0",
-          "from": "libmime@2.1.0",
           "resolved": "https://registry.npmjs.org/libmime/-/libmime-2.1.0.tgz",
+          "integrity": "sha1-Ubx23iKDFh65BRxLyArtcT5P0c0=",
+          "requires": {
+            "iconv-lite": "0.4.13",
+            "libbase64": "0.1.0",
+            "libqp": "1.1.0"
+          },
           "dependencies": {
             "iconv-lite": {
               "version": "0.4.13",
-              "from": "iconv-lite@0.4.13",
-              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz"
+              "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
+              "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI="
             }
           }
         },
         "libqp": {
           "version": "1.1.0",
-          "from": "libqp@1.1.0",
-          "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/libqp/-/libqp-1.1.0.tgz",
+          "integrity": "sha1-9ebgatdLeU+1tbZpiL9yjvHe2+g="
         },
         "lodash": {
           "version": "4.17.4",
-          "from": "lodash@>=4.14.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
         },
         "mailcomposer": {
           "version": "3.12.0",
-          "from": "mailcomposer@3.12.0",
-          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-3.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/mailcomposer/-/mailcomposer-3.12.0.tgz",
+          "integrity": "sha1-nF4RiKqOHGLsi4a9Q0aBArY56Pk=",
+          "requires": {
+            "buildmail": "3.10.0",
+            "libmime": "2.1.0"
+          }
         },
         "media-typer": {
           "version": "0.3.0",
-          "from": "media-typer@0.3.0",
-          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+          "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
         },
         "merge-descriptors": {
           "version": "1.0.1",
-          "from": "merge-descriptors@1.0.1",
-          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+          "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
         },
         "methods": {
           "version": "1.1.2",
-          "from": "methods@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+          "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
         },
         "mime": {
           "version": "1.4.1",
-          "from": "mime@1.4.1",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+          "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
         },
         "mime-db": {
           "version": "1.30.0",
-          "from": "mime-db@>=1.30.0 <1.31.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
         },
         "mime-types": {
           "version": "2.1.17",
-          "from": "mime-types@>=2.1.16 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "~1.30.0"
+          }
         },
         "minimist": {
           "version": "0.0.10",
-          "from": "minimist@>=0.0.1 <0.1.0",
-          "resolved": "http://npm.skunkhenry.com/minimist/-/minimist-0.0.10.tgz"
+          "resolved": "http://npm.skunkhenry.com/minimist/-/minimist-0.0.10.tgz",
+          "integrity": "sha1-3j+YVD2/lggr5IrRoMfNqDYwHc8="
         },
         "moment": {
           "version": "2.19.3",
-          "from": "moment@2.19.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
         },
         "mongodb": {
           "version": "2.1.18",
-          "from": "mongodb@2.1.18",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz"
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.1.18.tgz",
+          "integrity": "sha1-KNQLUVsr5NWmn/3UxTXw30MuQJc=",
+          "requires": {
+            "es6-promise": "3.0.2",
+            "mongodb-core": "1.3.18",
+            "readable-stream": "1.0.31"
+          }
         },
         "mongodb-core": {
           "version": "1.3.18",
-          "from": "mongodb-core@1.3.18",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz"
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.18.tgz",
+          "integrity": "sha1-kGhLO3xzVtZa41Y5HTCw8kiATHo=",
+          "requires": {
+            "bson": "~0.4.23",
+            "require_optional": "~1.0.0"
+          }
         },
         "mongoose": {
           "version": "4.11.14",
-          "from": "mongoose@4.11.14",
           "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.14.tgz",
+          "integrity": "sha1-uFQCqvKMXD5FyO+T/mlUTqpdAPM=",
+          "requires": {
+            "async": "2.1.4",
+            "bson": "~1.0.4",
+            "hooks-fixed": "2.0.0",
+            "kareem": "1.5.0",
+            "mongodb": "2.2.31",
+            "mpath": "0.3.0",
+            "mpromise": "0.5.5",
+            "mquery": "2.3.2",
+            "ms": "2.0.0",
+            "muri": "1.2.2",
+            "regexp-clone": "0.0.1",
+            "sliced": "1.0.1"
+          },
           "dependencies": {
             "async": {
               "version": "2.1.4",
-              "from": "async@2.1.4",
-              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
+              "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+              "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+              "requires": {
+                "lodash": "^4.14.0"
+              }
             },
             "bson": {
               "version": "1.0.4",
-              "from": "bson@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+              "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
             },
             "es6-promise": {
               "version": "3.2.1",
-              "from": "es6-promise@3.2.1",
-              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+              "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
             },
             "isarray": {
               "version": "1.0.0",
-              "from": "isarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+              "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
             },
             "mongodb": {
               "version": "2.2.31",
-              "from": "mongodb@2.2.31",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz"
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz",
+              "integrity": "sha1-GUBEXGYeGSF7s7+CRdmFSq71SNs=",
+              "requires": {
+                "es6-promise": "3.2.1",
+                "mongodb-core": "2.1.15",
+                "readable-stream": "2.2.7"
+              }
             },
             "mongodb-core": {
               "version": "2.1.15",
-              "from": "mongodb-core@2.1.15",
-              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz"
+              "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz",
+              "integrity": "sha1-hB9TuH//9MdFgYnDXIroJ+EWl2Q=",
+              "requires": {
+                "bson": "~1.0.4",
+                "require_optional": "~1.0.0"
+              }
             },
             "readable-stream": {
               "version": "2.2.7",
-              "from": "readable-stream@2.2.7",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz"
+              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+              "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+              "requires": {
+                "buffer-shims": "~1.0.0",
+                "core-util-is": "~1.0.0",
+                "inherits": "~2.0.1",
+                "isarray": "~1.0.0",
+                "process-nextick-args": "~1.0.6",
+                "string_decoder": "~1.0.0",
+                "util-deprecate": "~1.0.1"
+              }
             },
             "string_decoder": {
               "version": "1.0.3",
-              "from": "string_decoder@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+              "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+              "requires": {
+                "safe-buffer": "~5.1.0"
+              }
             }
           }
         },
         "mongoose-filter-denormalize": {
           "version": "0.2.1",
-          "from": "mongoose-filter-denormalize@0.2.1",
           "resolved": "https://registry.npmjs.org/mongoose-filter-denormalize/-/mongoose-filter-denormalize-0.2.1.tgz",
+          "integrity": "sha1-SUhd/n+6xuegc7Jha7CRJapmX74=",
+          "requires": {
+            "lodash": "~2.2.0",
+            "mongoose": "~3.6.0",
+            "sanitizer": "~0.1.0"
+          },
           "dependencies": {
             "bson": {
               "version": "0.2.2",
-              "from": "bson@0.2.2",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.2.tgz"
+              "resolved": "https://registry.npmjs.org/bson/-/bson-0.2.2.tgz",
+              "integrity": "sha1-Pb+YSsudM6aHi0bm+3r71hGFamA="
             },
             "lodash": {
               "version": "2.2.1",
-              "from": "lodash@>=2.2.0 <2.3.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.2.1.tgz",
+              "integrity": "sha1-ypNf0UqzwMhyq6zxmLnNpQFECGc="
             },
             "mongodb": {
               "version": "1.3.19",
-              "from": "mongodb@1.3.19",
-              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.3.19.tgz"
+              "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-1.3.19.tgz",
+              "integrity": "sha1-8inbJAmPAZ2G0TWq+KGrXyZYsdQ=",
+              "requires": {
+                "bson": "0.2.2",
+                "kerberos": "0.0.3"
+              }
             },
             "mongoose": {
               "version": "3.6.20",
-              "from": "mongoose@>=3.6.0 <3.7.0",
-              "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.6.20.tgz"
+              "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-3.6.20.tgz",
+              "integrity": "sha1-RyY4Q+a4EuogfuwQTECjbI0hX1M=",
+              "requires": {
+                "hooks": "0.2.1",
+                "mongodb": "1.3.19",
+                "mpath": "0.1.1",
+                "mpromise": "0.2.1",
+                "ms": "0.1.0",
+                "muri": "0.3.1",
+                "regexp-clone": "0.0.1",
+                "sliced": "0.0.5"
+              }
             },
             "mpath": {
               "version": "0.1.1",
-              "from": "mpath@0.1.1",
-              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz"
+              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.1.1.tgz",
+              "integrity": "sha1-I9qFK3wjLuCX9HWdKcDunNItXkY="
             },
             "mpromise": {
               "version": "0.2.1",
-              "from": "mpromise@0.2.1",
               "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.2.1.tgz",
+              "integrity": "sha1-+73CjLAgfkm4pOsaTAzqbC3nlMg=",
+              "requires": {
+                "sliced": "0.0.4"
+              },
               "dependencies": {
                 "sliced": {
                   "version": "0.0.4",
-                  "from": "sliced@0.0.4",
-                  "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.4.tgz"
+                  "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.4.tgz",
+                  "integrity": "sha1-NPiabbHzH6Ul9aVw9bz4d88JVe4="
                 }
               }
             },
             "ms": {
               "version": "0.1.0",
-              "from": "ms@0.1.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-0.1.0.tgz",
+              "integrity": "sha1-8h+sSQ2vHXZn/RgP6QdzicyUQrI="
             },
             "muri": {
               "version": "0.3.1",
-              "from": "muri@0.3.1",
-              "resolved": "https://registry.npmjs.org/muri/-/muri-0.3.1.tgz"
+              "resolved": "https://registry.npmjs.org/muri/-/muri-0.3.1.tgz",
+              "integrity": "sha1-hhiJxchX8aQ3AL7oXVBzH2FyfJo="
             },
             "sliced": {
               "version": "0.0.5",
-              "from": "sliced@0.0.5",
-              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+              "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
             }
           }
         },
         "mongoose-timestamp": {
           "version": "0.3.0",
-          "from": "mongoose-timestamp@0.3.0",
-          "resolved": "https://registry.npmjs.org/mongoose-timestamp/-/mongoose-timestamp-0.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/mongoose-timestamp/-/mongoose-timestamp-0.3.0.tgz",
+          "integrity": "sha1-+zCmUfFFzQOFmama2Ow0FBB4k1k="
         },
         "mongoose-unique-validator": {
           "version": "0.3.0",
-          "from": "mongoose-unique-validator@0.3.0",
-          "resolved": "https://registry.npmjs.org/mongoose-unique-validator/-/mongoose-unique-validator-0.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/mongoose-unique-validator/-/mongoose-unique-validator-0.3.0.tgz",
+          "integrity": "sha1-odI705NYM3fTg2u4fQFUpAmUbZk="
         },
         "mongoose-validator": {
           "version": "1.2.5",
-          "from": "mongoose-validator@1.2.5",
-          "resolved": "https://registry.npmjs.org/mongoose-validator/-/mongoose-validator-1.2.5.tgz"
+          "resolved": "https://registry.npmjs.org/mongoose-validator/-/mongoose-validator-1.2.5.tgz",
+          "integrity": "sha1-IOzOlj0ufqnCRKNUlKpzxDWpWNs=",
+          "requires": {
+            "underscore": "^1.8.3",
+            "validator": "^4.0.2"
+          }
         },
         "mpath": {
           "version": "0.3.0",
-          "from": "mpath@0.3.0",
-          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+          "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
         },
         "mpromise": {
           "version": "0.5.5",
-          "from": "mpromise@0.5.5",
-          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
+          "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+          "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
         },
         "mquery": {
           "version": "2.3.2",
-          "from": "mquery@2.3.2",
           "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
+          "integrity": "sha1-4sYK0RfPCA8u+x7N0UTnu/+/yhE=",
+          "requires": {
+            "bluebird": "^3.5.0",
+            "debug": "^2.6.9",
+            "regexp-clone": "^0.0.1",
+            "sliced": "0.0.5"
+          },
           "dependencies": {
             "sliced": {
               "version": "0.0.5",
-              "from": "sliced@0.0.5",
-              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+              "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
             }
           }
         },
         "ms": {
           "version": "2.0.0",
-          "from": "ms@2.0.0",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
         },
         "muri": {
           "version": "1.2.2",
-          "from": "muri@1.2.2",
-          "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz",
+          "integrity": "sha1-YxmBMmUNsIoEzHnM0A3Tia/SYxw="
         },
         "negotiator": {
           "version": "0.6.1",
-          "from": "negotiator@0.6.1",
-          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+          "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
         },
         "node-fingerprint": {
           "version": "0.0.2",
-          "from": "node-fingerprint@0.0.2",
-          "resolved": "https://registry.npmjs.org/node-fingerprint/-/node-fingerprint-0.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/node-fingerprint/-/node-fingerprint-0.0.2.tgz",
+          "integrity": "sha1-Mcur63GmeufdWn3AQuUcPHWGhQE="
         },
         "nodemailer": {
           "version": "2.6.4",
-          "from": "nodemailer@2.6.4",
-          "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.6.4.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-2.6.4.tgz",
+          "integrity": "sha1-ViBwfFX6xnS24uXkJXCLmtXGttY=",
+          "requires": {
+            "libmime": "2.1.0",
+            "mailcomposer": "3.12.0",
+            "nodemailer-direct-transport": "3.3.2",
+            "nodemailer-shared": "1.1.0",
+            "nodemailer-smtp-pool": "2.8.2",
+            "nodemailer-smtp-transport": "2.7.2",
+            "socks": "1.1.9"
+          }
         },
         "nodemailer-direct-transport": {
           "version": "3.3.2",
-          "from": "nodemailer-direct-transport@3.3.2",
-          "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-direct-transport/-/nodemailer-direct-transport-3.3.2.tgz",
+          "integrity": "sha1-6W+vuQNYVglH5WkBfZfmBzilCoY=",
+          "requires": {
+            "nodemailer-shared": "1.1.0",
+            "smtp-connection": "2.12.0"
+          }
         },
         "nodemailer-fetch": {
           "version": "1.6.0",
-          "from": "nodemailer-fetch@1.6.0",
-          "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-fetch/-/nodemailer-fetch-1.6.0.tgz",
+          "integrity": "sha1-ecSQihwPXzdbc/6IjamCj23JY6Q="
         },
         "nodemailer-sendgrid-transport": {
           "version": "0.2.0",
-          "from": "nodemailer-sendgrid-transport@0.2.0",
-          "resolved": "https://registry.npmjs.org/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-sendgrid-transport/-/nodemailer-sendgrid-transport-0.2.0.tgz",
+          "integrity": "sha1-pRZZO/49HyeM/hcGDh2yNlio9Pw=",
+          "requires": {
+            "sendgrid": "^1.8.0"
+          }
         },
         "nodemailer-shared": {
           "version": "1.1.0",
-          "from": "nodemailer-shared@1.1.0",
-          "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-shared/-/nodemailer-shared-1.1.0.tgz",
+          "integrity": "sha1-z1mU4v0mjQD1zw+nZ6CBae2wfsA=",
+          "requires": {
+            "nodemailer-fetch": "1.6.0"
+          }
         },
         "nodemailer-smtp-pool": {
           "version": "2.8.2",
-          "from": "nodemailer-smtp-pool@2.8.2",
-          "resolved": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-smtp-pool/-/nodemailer-smtp-pool-2.8.2.tgz",
+          "integrity": "sha1-LrlNbPhXgLG0clzoU7nL1ejajHI=",
+          "requires": {
+            "nodemailer-shared": "1.1.0",
+            "nodemailer-wellknown": "0.1.10",
+            "smtp-connection": "2.12.0"
+          }
         },
         "nodemailer-smtp-transport": {
           "version": "2.7.2",
-          "from": "nodemailer-smtp-transport@2.7.2",
-          "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-smtp-transport/-/nodemailer-smtp-transport-2.7.2.tgz",
+          "integrity": "sha1-A9ccdjFPFKx9vHvwM6am0W1n+3c=",
+          "requires": {
+            "nodemailer-shared": "1.1.0",
+            "nodemailer-wellknown": "0.1.10",
+            "smtp-connection": "2.12.0"
+          }
         },
         "nodemailer-wellknown": {
           "version": "0.1.10",
-          "from": "nodemailer-wellknown@0.1.10",
-          "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz"
+          "resolved": "https://registry.npmjs.org/nodemailer-wellknown/-/nodemailer-wellknown-0.1.10.tgz",
+          "integrity": "sha1-WG24EB2zDLRDjrVGc3pBqtDPE9U="
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "on-finished": {
           "version": "2.3.0",
-          "from": "on-finished@>=2.3.0 <2.4.0",
-          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+          "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+          "requires": {
+            "ee-first": "1.1.1"
+          }
         },
         "optimist": {
           "version": "0.6.1",
-          "from": "optimist@0.6.1",
-          "resolved": "http://npm.skunkhenry.com/optimist/-/optimist-0.6.1.tgz"
+          "resolved": "http://npm.skunkhenry.com/optimist/-/optimist-0.6.1.tgz",
+          "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+          "requires": {
+            "minimist": "~0.0.1",
+            "wordwrap": "~0.0.2"
+          }
         },
         "parseurl": {
           "version": "1.3.2",
-          "from": "parseurl@>=1.3.2 <1.4.0",
-          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+          "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
         },
         "path-to-regexp": {
           "version": "0.1.7",
-          "from": "path-to-regexp@0.1.7",
-          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+          "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
         },
         "performance-now": {
           "version": "2.1.0",
-          "from": "performance-now@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "proxy-addr": {
           "version": "2.0.2",
-          "from": "proxy-addr@>=2.0.2 <2.1.0",
-          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.2.tgz",
+          "integrity": "sha1-ZXFQT0e7mI7IGAJT+F3X4UlSvew=",
+          "requires": {
+            "forwarded": "~0.1.2",
+            "ipaddr.js": "1.5.2"
+          }
         },
         "punycode": {
           "version": "1.4.1",
-          "from": "punycode@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qs": {
           "version": "6.5.1",
-          "from": "qs@6.5.1",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
         },
         "range-parser": {
           "version": "1.2.0",
-          "from": "range-parser@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
         },
         "raw-body": {
           "version": "2.3.2",
-          "from": "raw-body@2.3.2",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz"
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+          "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+          "requires": {
+            "bytes": "3.0.0",
+            "http-errors": "1.6.2",
+            "iconv-lite": "0.4.19",
+            "unpipe": "1.0.0"
+          }
         },
         "rc": {
           "version": "0.4.0",
-          "from": "rc@0.4.0",
-          "resolved": "https://registry.npmjs.org/rc/-/rc-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/rc/-/rc-0.4.0.tgz",
+          "integrity": "sha1-ziSiAprZTDpA0JYEqHInAn1yENM=",
+          "requires": {
+            "deep-extend": "~0.2.5",
+            "ini": "~1.1.0",
+            "minimist": "~0.0.7",
+            "strip-json-comments": "0.1.x"
+          }
         },
         "readable-stream": {
           "version": "1.0.31",
-          "from": "readable-stream@1.0.31",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.31.tgz",
+          "integrity": "sha1-jyUC4LyeOw2huUUgqrtOJgPsr64=",
+          "requires": {
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "0.0.1",
+            "string_decoder": "~0.10.x"
+          }
         },
         "redis": {
           "version": "0.8.2",
-          "from": "redis@0.8.2",
-          "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/redis/-/redis-0.8.2.tgz",
+          "integrity": "sha1-9ySiFNoVvq2S3Fl5B86CIi/z6P8="
         },
         "regexp-clone": {
           "version": "0.0.1",
-          "from": "regexp-clone@0.0.1",
-          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+          "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
         },
         "request": {
           "version": "2.83.0",
-          "from": "request@2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz"
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
         },
         "require_optional": {
           "version": "1.0.1",
-          "from": "require_optional@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+          "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+          "requires": {
+            "resolve-from": "^2.0.0",
+            "semver": "^5.1.0"
+          }
         },
         "resolve-from": {
           "version": "2.0.0",
-          "from": "resolve-from@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "from": "safe-buffer@5.1.1",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
         },
         "sanitizer": {
           "version": "0.1.3",
-          "from": "sanitizer@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/sanitizer/-/sanitizer-0.1.3.tgz",
+          "integrity": "sha1-1PCvdHXZp7ryqeWmEXGLqheKOeE="
         },
         "semver": {
           "version": "5.4.1",
-          "from": "semver@>=5.1.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
         },
         "send": {
           "version": "0.16.0",
-          "from": "send@0.16.0",
-          "resolved": "https://registry.npmjs.org/send/-/send-0.16.0.tgz"
+          "resolved": "https://registry.npmjs.org/send/-/send-0.16.0.tgz",
+          "integrity": "sha1-FjONu5ou3krVe0hCDsO4LY6ApXs=",
+          "requires": {
+            "debug": "2.6.9",
+            "depd": "~1.1.1",
+            "destroy": "~1.0.4",
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "etag": "~1.8.1",
+            "fresh": "0.5.2",
+            "http-errors": "~1.6.2",
+            "mime": "1.4.1",
+            "ms": "2.0.0",
+            "on-finished": "~2.3.0",
+            "range-parser": "~1.2.0",
+            "statuses": "~1.3.1"
+          }
         },
         "sendgrid": {
           "version": "1.9.2",
-          "from": "sendgrid@>=1.8.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/sendgrid/-/sendgrid-1.9.2.tgz",
+          "integrity": "sha1-1AfmogawoqaWQkbdnAZBwQvwLxk=",
+          "requires": {
+            "lodash": "^3.0.1 || ^2.0.0",
+            "mime": "^1.2.9",
+            "request": "^2.60.0",
+            "smtpapi": "^1.2.0"
+          },
           "dependencies": {
             "lodash": {
               "version": "3.10.1",
-              "from": "lodash@>=3.0.1 <4.0.0||>=2.0.0 <3.0.0",
-              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz"
+              "resolved": "https://registry.npmjs.org/lodash/-/lodash-3.10.1.tgz",
+              "integrity": "sha1-W/Rejkm6QYnhfUgnid/RW9FAt7Y="
             }
           }
         },
         "serve-static": {
           "version": "1.13.0",
-          "from": "serve-static@1.13.0",
-          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz"
+          "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.0.tgz",
+          "integrity": "sha1-gQyR24AOlLoofq5rTgbKq5/cFvE=",
+          "requires": {
+            "encodeurl": "~1.0.1",
+            "escape-html": "~1.0.3",
+            "parseurl": "~1.3.2",
+            "send": "0.16.0"
+          }
         },
         "setprototypeof": {
           "version": "1.1.0",
-          "from": "setprototypeof@1.1.0",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+          "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
         },
         "shimmer": {
           "version": "1.2.0",
-          "from": "shimmer@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
+          "integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU="
         },
         "sliced": {
           "version": "1.0.1",
-          "from": "sliced@1.0.1",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+          "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
         },
         "smart-buffer": {
           "version": "1.1.15",
-          "from": "smart-buffer@>=1.0.4 <2.0.0",
-          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz"
+          "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-1.1.15.tgz",
+          "integrity": "sha1-fxFLW2X6s+KjWqd1uxLw0cZJvxY="
         },
         "smtp-connection": {
           "version": "2.12.0",
-          "from": "smtp-connection@2.12.0",
-          "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/smtp-connection/-/smtp-connection-2.12.0.tgz",
+          "integrity": "sha1-1275EnyyPCJZ7bHoNJwujV4tdME=",
+          "requires": {
+            "httpntlm": "1.6.1",
+            "nodemailer-shared": "1.1.0"
+          }
         },
         "smtpapi": {
           "version": "1.3.1",
-          "from": "smtpapi@>=1.2.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/smtpapi/-/smtpapi-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/smtpapi/-/smtpapi-1.3.1.tgz",
+          "integrity": "sha1-GHQp607SffSjz/0j8OAkXN/mh9Q="
         },
         "sntp": {
           "version": "2.1.0",
-          "from": "sntp@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
         },
         "socks": {
           "version": "1.1.9",
-          "from": "socks@1.1.9",
-          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz"
+          "resolved": "https://registry.npmjs.org/socks/-/socks-1.1.9.tgz",
+          "integrity": "sha1-Yo1+TQSRJDVEWsC25Fk3bLPm1pE=",
+          "requires": {
+            "ip": "^1.1.2",
+            "smart-buffer": "^1.0.4"
+          }
         },
         "sshpk": {
           "version": "1.13.1",
-          "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
+          }
         },
         "statuses": {
           "version": "1.3.1",
-          "from": "statuses@>=1.3.1 <1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.3.1.tgz",
+          "integrity": "sha1-+vUbnrdKrvOzrPStX2Gr8ky3uT4="
         },
         "string_decoder": {
           "version": "0.10.31",
-          "from": "string_decoder@>=0.10.0 <0.11.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "strip-json-comments": {
           "version": "0.1.3",
-          "from": "strip-json-comments@>=0.1.0 <0.2.0",
-          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz"
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-0.1.3.tgz",
+          "integrity": "sha1-Fkxk43Coo8wAyeAbU55WmCPw7lQ="
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "from": "tweetnacl@>=0.14.0 <0.15.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "type-is": {
           "version": "1.6.15",
-          "from": "type-is@>=1.6.15 <1.7.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz"
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.15.tgz",
+          "integrity": "sha1-yrEPtJCeRByChC6v4a1kbIGARBA=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.1.15"
+          }
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         },
         "unpipe": {
           "version": "1.0.0",
-          "from": "unpipe@1.0.0",
-          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+          "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "from": "util-deprecate@>=1.0.1 <1.1.0",
-          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "utils-merge": {
           "version": "1.0.1",
-          "from": "utils-merge@1.0.1",
-          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+          "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
         },
         "uuid": {
           "version": "3.1.0",
-          "from": "uuid@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
         },
         "validator": {
           "version": "4.9.0",
-          "from": "validator@>=4.0.2 <5.0.0",
           "resolved": "https://registry.npmjs.org/validator/-/validator-4.9.0.tgz",
+          "integrity": "sha1-CC/84qdhSP8HqOienCukOq8S7Ew=",
+          "requires": {
+            "depd": "1.1.0"
+          },
           "dependencies": {
             "depd": {
               "version": "1.1.0",
-              "from": "depd@1.1.0",
-              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz"
+              "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.0.tgz",
+              "integrity": "sha1-4b2Cxqq2ztlluXuIsX7T5SjKGMM="
             }
           }
         },
         "vary": {
           "version": "1.1.2",
-          "from": "vary@>=1.1.2 <1.2.0",
-          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+          "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
         },
         "verror": {
           "version": "1.10.0",
-          "from": "verror@1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
         },
         "wordwrap": {
           "version": "0.0.3",
-          "from": "wordwrap@>=0.0.2 <0.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+          "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
         }
       }
     },
     "fh-messaging-client": {
       "version": "1.0.4",
-      "from": "fh-messaging-client@1.0.4",
       "resolved": "https://registry.npmjs.org/fh-messaging-client/-/fh-messaging-client-1.0.4.tgz",
+      "integrity": "sha1-k3W8+P5pXE6u7SI519jp13uoM6U=",
+      "requires": {
+        "request": "^2.78.0",
+        "underscore": "1.8.0"
+      },
       "dependencies": {
         "request": {
           "version": "2.78.0",
-          "from": "request@>=2.78.0 <3.0.0",
           "resolved": "https://registry.npmjs.org/request/-/request-2.78.0.tgz",
+          "integrity": "sha1-4cjew0bhyBkjskrNszfxHeyr6cw=",
+          "requires": {
+            "aws-sign2": "~0.6.0",
+            "aws4": "^1.2.1",
+            "caseless": "~0.11.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.0",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.1.1",
+            "har-validator": "~2.0.6",
+            "hawk": "~3.1.3",
+            "http-signature": "~1.1.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.7",
+            "node-uuid": "~1.4.7",
+            "oauth-sign": "~0.8.1",
+            "qs": "~6.3.0",
+            "stringstream": "~0.0.4",
+            "tough-cookie": "~2.3.0",
+            "tunnel-agent": "~0.4.1"
+          },
           "dependencies": {
             "aws-sign2": {
               "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz",
+              "integrity": "sha1-FDQt0428yU0OW4fXY81jYSwOeU8="
             },
             "aws4": {
               "version": "1.5.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz",
+              "integrity": "sha1-Cin/t5wxyecS7rCH6OemS0pW11U="
             },
             "caseless": {
               "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
+              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz",
+              "integrity": "sha1-cVuW6phBWTzDMGeSP17GDr2k99c="
             },
             "combined-stream": {
               "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
               "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+              "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+              "requires": {
+                "delayed-stream": "~1.0.0"
+              },
               "dependencies": {
                 "delayed-stream": {
                   "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+                  "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
                 }
               }
             },
             "extend": {
               "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz",
+              "integrity": "sha1-WkdDU7nzNT3dgXbf03uRyDpG8dQ="
             },
             "forever-agent": {
               "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+              "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
             },
             "form-data": {
               "version": "2.1.2",
-              "from": "form-data@>=2.1.1 <2.2.0",
               "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
+              "integrity": "sha1-icNTQAi5fq2ky7FX1Y9vXfAl6uQ=",
+              "requires": {
+                "asynckit": "^0.4.0",
+                "combined-stream": "^1.0.5",
+                "mime-types": "^2.1.12"
+              },
               "dependencies": {
                 "asynckit": {
                   "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+                  "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
                 }
               }
             },
             "har-validator": {
               "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
               "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
+              "integrity": "sha1-zcvAgYgmWtEZtqWnyKtw7s+10n0=",
+              "requires": {
+                "chalk": "^1.1.1",
+                "commander": "^2.9.0",
+                "is-my-json-valid": "^2.12.4",
+                "pinkie-promise": "^2.0.0"
+              },
               "dependencies": {
                 "chalk": {
                   "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <2.0.0",
                   "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+                  "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+                  "requires": {
+                    "ansi-styles": "^2.2.1",
+                    "escape-string-regexp": "^1.0.2",
+                    "has-ansi": "^2.0.0",
+                    "strip-ansi": "^3.0.0",
+                    "supports-color": "^2.0.0"
+                  },
                   "dependencies": {
                     "ansi-styles": {
                       "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
+                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
+                      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
                     },
                     "escape-string-regexp": {
                       "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
+                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+                      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
                     },
                     "has-ansi": {
                       "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
                       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
+                      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+                      "requires": {
+                        "ansi-regex": "^2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                         }
                       }
                     },
                     "strip-ansi": {
                       "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
                       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+                      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+                      "requires": {
+                        "ansi-regex": "^2.0.0"
+                      },
                       "dependencies": {
                         "ansi-regex": {
                           "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz",
+                          "integrity": "sha1-xQYbbg74qBd15Q9dZhUb9r83EQc="
                         }
                       }
                     },
                     "supports-color": {
                       "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
+                      "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
                     }
                   }
                 },
                 "commander": {
                   "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
+                  "integrity": "sha1-nJkJQXbhIkDLItbFFGCYQA/g99Q=",
+                  "requires": {
+                    "graceful-readlink": ">= 1.0.0"
+                  },
                   "dependencies": {
                     "graceful-readlink": {
                       "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz",
+                      "integrity": "sha1-TK+tdrxi8C+gObL5Tpo906ORpyU="
                     }
                   }
                 },
                 "is-my-json-valid": {
                   "version": "2.15.0",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
                   "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
+                  "integrity": "sha1-k27do8o8IR/ZjzstPgjaQ/eykVs=",
+                  "requires": {
+                    "generate-function": "^2.0.0",
+                    "generate-object-property": "^1.1.0",
+                    "jsonpointer": "^4.0.0",
+                    "xtend": "^4.0.0"
+                  },
                   "dependencies": {
                     "generate-function": {
                       "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz",
+                      "integrity": "sha1-aFj+fAlpt9TpCTM3ZHrHn2DfvnQ="
                     },
                     "generate-object-property": {
                       "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
+                      "integrity": "sha1-nA4cQDCM6AT0eDYYuTf6iPmdUNA=",
+                      "requires": {
+                        "is-property": "^1.0.0"
+                      },
                       "dependencies": {
                         "is-property": {
                           "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
+                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz",
+                          "integrity": "sha1-V/4cTkhHTt1lsJkR8msc1Ald2oQ="
                         }
                       }
                     },
                     "jsonpointer": {
                       "version": "4.0.0",
-                      "from": "jsonpointer@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz",
+                      "integrity": "sha1-ZmHhYdL8RF8Z+YQwIxNDci4fy9U="
                     },
                     "xtend": {
                       "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+                      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
                     }
                   }
                 },
                 "pinkie-promise": {
                   "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
                   "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+                  "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+                  "requires": {
+                    "pinkie": "^2.0.0"
+                  },
                   "dependencies": {
                     "pinkie": {
                       "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+                      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
                     }
                   }
                 }
@@ -3655,116 +5056,170 @@
             },
             "hawk": {
               "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
               "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
+              "integrity": "sha1-B4REvXwWQLD+VA0sm3PVlnjo4cQ=",
+              "requires": {
+                "boom": "2.x.x",
+                "cryptiles": "2.x.x",
+                "hoek": "2.x.x",
+                "sntp": "1.x.x"
+              },
               "dependencies": {
                 "boom": {
                   "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
+                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz",
+                  "integrity": "sha1-OciRjO/1eZ+D+UkqhI9iWt0Mdm8=",
+                  "requires": {
+                    "hoek": "2.x.x"
+                  }
                 },
                 "cryptiles": {
                   "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz",
+                  "integrity": "sha1-O9/s3GCBR8HGcgL6KR59ylnqo7g=",
+                  "requires": {
+                    "boom": "2.x.x"
+                  }
                 },
                 "hoek": {
                   "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz",
+                  "integrity": "sha1-ILt0A9POo5jpHcRxCo/xuCdKJe0="
                 },
                 "sntp": {
                   "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
+                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz",
+                  "integrity": "sha1-ZUEYTMkK7qbG57NeJlkIJEPGYZg=",
+                  "requires": {
+                    "hoek": "2.x.x"
+                  }
                 }
               }
             },
             "http-signature": {
               "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
               "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
+              "integrity": "sha1-33LiZwZs0Kxn+3at+OE0qPvPkb8=",
+              "requires": {
+                "assert-plus": "^0.2.0",
+                "jsprim": "^1.2.2",
+                "sshpk": "^1.7.0"
+              },
               "dependencies": {
                 "assert-plus": {
                   "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
+                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz",
+                  "integrity": "sha1-104bh+ev/A24qttwIfP+SBAasjQ="
                 },
                 "jsprim": {
                   "version": "1.3.1",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
                   "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
+                  "integrity": "sha1-KnJW9wQSop7jZwqspiWZTE3P8lI=",
+                  "requires": {
+                    "extsprintf": "1.0.2",
+                    "json-schema": "0.2.3",
+                    "verror": "1.3.6"
+                  },
                   "dependencies": {
                     "extsprintf": {
                       "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz",
+                      "integrity": "sha1-4QgOBljjALBilJkMxw4VAiNf1VA="
                     },
                     "json-schema": {
                       "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+                      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
                     },
                     "verror": {
                       "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
+                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz",
+                      "integrity": "sha1-z/XfEpRtKX0rqu+qJoniW+AcAFw=",
+                      "requires": {
+                        "extsprintf": "1.0.2"
+                      }
                     }
                   }
                 },
                 "sshpk": {
                   "version": "1.10.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
                   "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
+                  "integrity": "sha1-MOGl0ykkSXShr2FREznVla9mOLA=",
+                  "requires": {
+                    "asn1": "~0.2.3",
+                    "assert-plus": "^1.0.0",
+                    "bcrypt-pbkdf": "^1.0.0",
+                    "dashdash": "^1.12.0",
+                    "ecc-jsbn": "~0.1.1",
+                    "getpass": "^0.1.1",
+                    "jodid25519": "^1.0.0",
+                    "jsbn": "~0.1.0",
+                    "tweetnacl": "~0.14.0"
+                  },
                   "dependencies": {
                     "asn1": {
                       "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+                      "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
                     },
                     "assert-plus": {
                       "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+                      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
                     },
                     "bcrypt-pbkdf": {
                       "version": "1.0.0",
-                      "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "optional": true
+                      "integrity": "sha1-PKdrhSQccXC/fZcD57mqdGMAQNQ=",
+                      "optional": true,
+                      "requires": {
+                        "tweetnacl": "^0.14.3"
+                      }
                     },
                     "dashdash": {
                       "version": "1.14.0",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
+                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz",
+                      "integrity": "sha1-KeSGxUGL8PNWA0qZPVFoajPoQUE=",
+                      "requires": {
+                        "assert-plus": "^1.0.0"
+                      }
                     },
                     "ecc-jsbn": {
                       "version": "0.1.1",
-                      "from": "ecc-jsbn@>=0.1.1 <0.2.0",
                       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "optional": true
+                      "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "~0.1.0"
+                      }
                     },
                     "getpass": {
                       "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
+                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz",
+                      "integrity": "sha1-KD/9n8ElaECHUxHBtg6MQBhxEOY=",
+                      "requires": {
+                        "assert-plus": "^1.0.0"
+                      }
                     },
                     "jodid25519": {
                       "version": "1.0.2",
-                      "from": "jodid25519@>=1.0.0 <2.0.0",
                       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "optional": true
+                      "integrity": "sha1-BtSRIlUJNBlHfUJWM2BuDpB4KWc=",
+                      "optional": true,
+                      "requires": {
+                        "jsbn": "~0.1.0"
+                      }
                     },
                     "jsbn": {
                       "version": "0.1.0",
-                      "from": "jsbn@>=0.1.0 <0.2.0",
                       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
+                      "integrity": "sha1-ZQmH2g3XT06/WhE3eiqi0nPpff0=",
                       "optional": true
                     },
                     "tweetnacl": {
                       "version": "0.14.3",
-                      "from": "tweetnacl@>=0.14.0 <0.15.0",
                       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
+                      "integrity": "sha1-PaOC9nDyXe1417PReSEZvKC3Ey0=",
                       "optional": true
                     }
                   }
@@ -3773,475 +5228,637 @@
             },
             "is-typedarray": {
               "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+              "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
             },
             "isstream": {
               "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+              "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
             },
             "json-stringify-safe": {
               "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+              "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
             },
             "mime-types": {
               "version": "2.1.12",
-              "from": "mime-types@>=2.1.7 <2.2.0",
               "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
+              "integrity": "sha1-FSuiVndwIN1GY/VMLnvCY4HnFyk=",
+              "requires": {
+                "mime-db": "~1.24.0"
+              },
               "dependencies": {
                 "mime-db": {
                   "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
+                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz",
+                  "integrity": "sha1-4tE/k58AFsbk6a0lqGUvEmxGfww="
                 }
               }
             },
             "node-uuid": {
               "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz",
+              "integrity": "sha1-baWhdmjEs91ZYjvaEc9/pMH2Cm8="
             },
             "oauth-sign": {
               "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+              "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
             },
             "qs": {
               "version": "6.3.0",
-              "from": "qs@>=6.3.0 <6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz",
+              "integrity": "sha1-9AOyZPI7wBIox0ExtAfxjV6l1EI="
             },
             "stringstream": {
               "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+              "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
             },
             "tough-cookie": {
               "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
               "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
+              "integrity": "sha1-8IH3bkyFcg5sN6X6ztc3FQ2EByo=",
+              "requires": {
+                "punycode": "^1.4.1"
+              },
               "dependencies": {
                 "punycode": {
                   "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                  "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
                 }
               }
             },
             "tunnel-agent": {
               "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
+              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz",
+              "integrity": "sha1-Y3PbdpCf5XDgjXNYM2Xtgop07us="
             }
           }
         },
         "underscore": {
           "version": "1.8.0",
-          "from": "underscore@1.8.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz",
+          "integrity": "sha1-60C052lNs+N28vQ5L7Ki+AMGPwE="
         }
       }
     },
     "fh-metrics-client": {
       "version": "1.0.5",
-      "from": "fh-metrics-client@1.0.5",
       "resolved": "https://registry.npmjs.org/fh-metrics-client/-/fh-metrics-client-1.0.5.tgz",
+      "integrity": "sha1-vvVDB3RvHifc7QI74VDeS1dz/ao=",
+      "requires": {
+        "moment": "2.19.3",
+        "request": "2.83.0",
+        "underscore": "1.8.0"
+      },
       "dependencies": {
         "ajv": {
           "version": "5.5.1",
-          "from": "ajv@>=5.1.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
+          "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+          "requires": {
+            "co": "^4.6.0",
+            "fast-deep-equal": "^1.0.0",
+            "fast-json-stable-stringify": "^2.0.0",
+            "json-schema-traverse": "^0.3.0"
+          }
         },
         "asn1": {
           "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz",
+          "integrity": "sha1-2sh4dxPJlmhJ/IGAd36+nB3fO4Y="
         },
         "assert-plus": {
           "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
+          "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
         },
         "asynckit": {
           "version": "0.4.0",
-          "from": "asynckit@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+          "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
         },
         "aws-sign2": {
           "version": "0.7.0",
-          "from": "aws-sign2@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
+          "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
         },
         "aws4": {
           "version": "1.6.0",
-          "from": "aws4@>=1.6.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
+          "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4="
         },
         "bcrypt-pbkdf": {
           "version": "1.0.1",
-          "from": "bcrypt-pbkdf@>=1.0.0 <2.0.0",
           "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "optional": true
+          "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+          "optional": true,
+          "requires": {
+            "tweetnacl": "^0.14.3"
+          }
         },
         "boom": {
           "version": "4.3.1",
-          "from": "boom@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
+          "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
         },
         "caseless": {
           "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
+          "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
         },
         "co": {
           "version": "4.6.0",
-          "from": "co@>=4.6.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz",
+          "integrity": "sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ="
         },
         "combined-stream": {
           "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
+          "integrity": "sha1-k4NwpXtKUd6ix3wV1cX9+JUWQAk=",
+          "requires": {
+            "delayed-stream": "~1.0.0"
+          }
         },
         "core-util-is": {
           "version": "1.0.2",
-          "from": "core-util-is@1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
         },
         "cryptiles": {
           "version": "3.1.2",
-          "from": "cryptiles@>=3.0.0 <4.0.0",
           "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
+          "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+          "requires": {
+            "boom": "5.x.x"
+          },
           "dependencies": {
             "boom": {
               "version": "5.2.0",
-              "from": "boom@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
+              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
+              "integrity": "sha1-XdnabuOl8wIHdDYpDLcX0/SlTgI=",
+              "requires": {
+                "hoek": "4.x.x"
+              }
             }
           }
         },
         "dashdash": {
           "version": "1.14.1",
-          "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
+          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
+          "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
         },
         "delayed-stream": {
           "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+          "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
         },
         "ecc-jsbn": {
           "version": "0.1.1",
-          "from": "ecc-jsbn@>=0.1.1 <0.2.0",
           "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
+          "integrity": "sha1-D8c6ntXw1Tw4GTOYUj735UN3dQU=",
+          "optional": true,
+          "requires": {
+            "jsbn": "~0.1.0"
+          }
         },
         "extend": {
           "version": "3.0.1",
-          "from": "extend@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz",
+          "integrity": "sha1-p1Xqe8Gt/MWjHOfnYtuq3F5jZEQ="
         },
         "extsprintf": {
           "version": "1.3.0",
-          "from": "extsprintf@1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
+          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
+          "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
         },
         "fast-deep-equal": {
           "version": "1.0.0",
-          "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz",
+          "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8="
         },
         "fast-json-stable-stringify": {
           "version": "2.0.0",
-          "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+          "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
         },
         "forever-agent": {
           "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+          "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
         },
         "form-data": {
           "version": "2.3.1",
-          "from": "form-data@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz",
+          "integrity": "sha1-b7lPvXGIUwbXPRXMSX/kzE7NRL8=",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.5",
+            "mime-types": "^2.1.12"
+          }
         },
         "getpass": {
           "version": "0.1.7",
-          "from": "getpass@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+          "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+          "requires": {
+            "assert-plus": "^1.0.0"
+          }
         },
         "har-schema": {
           "version": "2.0.0",
-          "from": "har-schema@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+          "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
         },
         "har-validator": {
           "version": "5.0.3",
-          "from": "har-validator@>=5.0.3 <5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+          "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+          "requires": {
+            "ajv": "^5.1.0",
+            "har-schema": "^2.0.0"
+          }
         },
         "hawk": {
           "version": "6.0.2",
-          "from": "hawk@>=6.0.2 <6.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
+          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+          "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+          "requires": {
+            "boom": "4.x.x",
+            "cryptiles": "3.x.x",
+            "hoek": "4.x.x",
+            "sntp": "2.x.x"
+          }
         },
         "hoek": {
           "version": "4.2.0",
-          "from": "hoek@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz",
+          "integrity": "sha1-ctnQdU9/4lyi0BrY+PmpRJqJUm0="
         },
         "http-signature": {
           "version": "1.2.0",
-          "from": "http-signature@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+          "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "jsprim": "^1.2.2",
+            "sshpk": "^1.7.0"
+          }
         },
         "is-typedarray": {
           "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+          "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
         },
         "isstream": {
           "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+          "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
         },
         "jsbn": {
           "version": "0.1.1",
-          "from": "jsbn@>=0.1.0 <0.2.0",
           "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+          "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
           "optional": true
         },
         "json-schema": {
           "version": "0.2.3",
-          "from": "json-schema@0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+          "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
         },
         "json-schema-traverse": {
           "version": "0.3.1",
-          "from": "json-schema-traverse@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+          "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
         },
         "json-stringify-safe": {
           "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+          "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
         },
         "jsprim": {
           "version": "1.4.1",
-          "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+          "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+          "requires": {
+            "assert-plus": "1.0.0",
+            "extsprintf": "1.3.0",
+            "json-schema": "0.2.3",
+            "verror": "1.10.0"
+          }
         },
         "mime-db": {
           "version": "1.30.0",
-          "from": "mime-db@>=1.30.0 <1.31.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz",
+          "integrity": "sha1-dMZD2i3Z1qRTmZY0ZbJtXKfXHwE="
         },
         "mime-types": {
           "version": "2.1.17",
-          "from": "mime-types@>=2.1.17 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz",
+          "integrity": "sha1-Cdejk/A+mVp5+K+Fe3Cp4KsWVXo=",
+          "requires": {
+            "mime-db": "~1.30.0"
+          }
         },
         "moment": {
           "version": "2.19.3",
-          "from": "moment@2.19.3",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz",
+          "integrity": "sha1-vbmdJw1tf9p4zA+6zoVeJ/59pp8="
         },
         "oauth-sign": {
           "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+          "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
         },
         "performance-now": {
           "version": "2.1.0",
-          "from": "performance-now@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+          "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
         },
         "punycode": {
           "version": "1.4.1",
-          "from": "punycode@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
         },
         "qs": {
           "version": "6.5.1",
-          "from": "qs@>=6.5.1 <6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
         },
         "request": {
           "version": "2.83.0",
-          "from": "request@2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz"
+          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz",
+          "integrity": "sha1-ygtl2gLtYpNYh4COb1EDgQNOM1Y=",
+          "requires": {
+            "aws-sign2": "~0.7.0",
+            "aws4": "^1.6.0",
+            "caseless": "~0.12.0",
+            "combined-stream": "~1.0.5",
+            "extend": "~3.0.1",
+            "forever-agent": "~0.6.1",
+            "form-data": "~2.3.1",
+            "har-validator": "~5.0.3",
+            "hawk": "~6.0.2",
+            "http-signature": "~1.2.0",
+            "is-typedarray": "~1.0.0",
+            "isstream": "~0.1.2",
+            "json-stringify-safe": "~5.0.1",
+            "mime-types": "~2.1.17",
+            "oauth-sign": "~0.8.2",
+            "performance-now": "^2.1.0",
+            "qs": "~6.5.1",
+            "safe-buffer": "^5.1.1",
+            "stringstream": "~0.0.5",
+            "tough-cookie": "~2.3.3",
+            "tunnel-agent": "^0.6.0",
+            "uuid": "^3.1.0"
+          }
         },
         "safe-buffer": {
           "version": "5.1.1",
-          "from": "safe-buffer@>=5.1.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
         },
         "sntp": {
           "version": "2.1.0",
-          "from": "sntp@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+          "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+          "requires": {
+            "hoek": "4.x.x"
+          }
         },
         "sshpk": {
           "version": "1.13.1",
-          "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
+          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz",
+          "integrity": "sha1-US322mKHFEMW3EwY/hzx2UBzm+M=",
+          "requires": {
+            "asn1": "~0.2.3",
+            "assert-plus": "^1.0.0",
+            "bcrypt-pbkdf": "^1.0.0",
+            "dashdash": "^1.12.0",
+            "ecc-jsbn": "~0.1.1",
+            "getpass": "^0.1.1",
+            "jsbn": "~0.1.0",
+            "tweetnacl": "~0.14.0"
+          }
         },
         "stringstream": {
           "version": "0.0.5",
-          "from": "stringstream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
+          "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg="
         },
         "tough-cookie": {
           "version": "2.3.3",
-          "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz"
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz",
+          "integrity": "sha1-C2GKVWW23qkL80JdBNVe3EdadWE=",
+          "requires": {
+            "punycode": "^1.4.1"
+          }
         },
         "tunnel-agent": {
           "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+          "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
         },
         "tweetnacl": {
           "version": "0.14.5",
-          "from": "tweetnacl@>=0.14.0 <0.15.0",
           "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+          "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
           "optional": true
         },
         "underscore": {
           "version": "1.8.0",
-          "from": "underscore@1.8.0",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz",
+          "integrity": "sha1-60C052lNs+N28vQ5L7Ki+AMGPwE="
         },
         "uuid": {
           "version": "3.1.0",
-          "from": "uuid@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz",
+          "integrity": "sha1-PdPT55Crwk17DToDT/q6vijrvAQ="
         },
         "verror": {
           "version": "1.10.0",
-          "from": "verror@1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+          "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+          "requires": {
+            "assert-plus": "^1.0.0",
+            "core-util-is": "1.0.2",
+            "extsprintf": "^1.2.0"
+          }
         }
       }
     },
     "fh-service-auth": {
       "version": "1.0.4",
-      "from": "fh-service-auth@1.0.4",
       "resolved": "https://registry.npmjs.org/fh-service-auth/-/fh-service-auth-1.0.4.tgz",
+      "integrity": "sha1-iWh1xAFkvUrDcfO1ggr9bE/SaOo=",
+      "requires": {
+        "async": "1.5.2",
+        "bunyan": "1.8.5",
+        "mongoose": "4.11.14",
+        "underscore": "1.8.3"
+      },
       "dependencies": {
         "async": {
           "version": "1.5.2",
-          "from": "async@1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
+          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo="
         },
         "bunyan": {
           "version": "1.8.5",
-          "from": "bunyan@1.8.5",
           "resolved": "https://registry.npmjs.org/bunyan/-/bunyan-1.8.5.tgz",
+          "integrity": "sha1-DWGegwBfuJBw9fR5gvwb8AYAh4o=",
+          "requires": {
+            "dtrace-provider": "~0.8",
+            "moment": "^2.10.6",
+            "mv": "~2",
+            "safe-json-stringify": "~1"
+          },
           "dependencies": {
             "dtrace-provider": {
               "version": "0.8.5",
-              "from": "dtrace-provider@>=0.8.0 <0.9.0",
               "resolved": "https://registry.npmjs.org/dtrace-provider/-/dtrace-provider-0.8.5.tgz",
+              "integrity": "sha1-mOu6Ihr6xG4cOf02hY2Pk2dSS5I=",
               "optional": true,
+              "requires": {
+                "nan": "^2.3.3"
+              },
               "dependencies": {
                 "nan": {
                   "version": "2.7.0",
-                  "from": "nan@>=2.3.3 <3.0.0",
                   "resolved": "https://registry.npmjs.org/nan/-/nan-2.7.0.tgz",
+                  "integrity": "sha1-2Vv3IeyHfgjbJ27T/G63j5CDrUY=",
                   "optional": true
                 }
               }
             },
             "moment": {
               "version": "2.19.1",
-              "from": "moment@>=2.10.6 <3.0.0",
               "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.1.tgz",
+              "integrity": "sha1-VtoaLRy/AdOLfhr8McELz6GSkWc=",
               "optional": true
             },
             "mv": {
               "version": "2.1.1",
-              "from": "mv@>=2.0.0 <3.0.0",
               "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+              "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
               "optional": true,
+              "requires": {
+                "mkdirp": "~0.5.1",
+                "ncp": "~2.0.0",
+                "rimraf": "~2.4.0"
+              },
               "dependencies": {
                 "mkdirp": {
                   "version": "0.5.1",
-                  "from": "mkdirp@>=0.5.1 <0.6.0",
                   "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
                   "optional": true,
+                  "requires": {
+                    "minimist": "0.0.8"
+                  },
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
-                      "from": "minimist@0.0.8",
                       "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
                       "optional": true
                     }
                   }
                 },
                 "ncp": {
                   "version": "2.0.0",
-                  "from": "ncp@>=2.0.0 <2.1.0",
                   "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+                  "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
                   "optional": true
                 },
                 "rimraf": {
                   "version": "2.4.5",
-                  "from": "rimraf@>=2.4.0 <2.5.0",
                   "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                  "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
                   "optional": true,
+                  "requires": {
+                    "glob": "^6.0.1"
+                  },
                   "dependencies": {
                     "glob": {
                       "version": "6.0.4",
-                      "from": "glob@>=6.0.1 <7.0.0",
                       "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
+                      "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
                       "optional": true,
+                      "requires": {
+                        "inflight": "^1.0.4",
+                        "inherits": "2",
+                        "minimatch": "2 || 3",
+                        "once": "^1.3.0",
+                        "path-is-absolute": "^1.0.0"
+                      },
                       "dependencies": {
                         "inflight": {
                           "version": "1.0.6",
-                          "from": "inflight@>=1.0.4 <2.0.0",
                           "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+                          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
                           "optional": true,
+                          "requires": {
+                            "once": "^1.3.0",
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
                               "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
                               "optional": true
                             }
                           }
                         },
                         "inherits": {
                           "version": "2.0.3",
-                          "from": "inherits@>=2.0.0 <3.0.0",
                           "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
                           "optional": true
                         },
                         "minimatch": {
                           "version": "3.0.4",
-                          "from": "minimatch@>=2.0.0 <3.0.0||>=3.0.0 <4.0.0",
                           "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+                          "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
                           "optional": true,
+                          "requires": {
+                            "brace-expansion": "^1.1.7"
+                          },
                           "dependencies": {
                             "brace-expansion": {
                               "version": "1.1.8",
-                              "from": "brace-expansion@>=1.1.7 <2.0.0",
                               "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.8.tgz",
+                              "integrity": "sha1-wHshHHyVLsH479Uad+8NHTmQopI=",
                               "optional": true,
+                              "requires": {
+                                "balanced-match": "^1.0.0",
+                                "concat-map": "0.0.1"
+                              },
                               "dependencies": {
                                 "balanced-match": {
                                   "version": "1.0.0",
-                                  "from": "balanced-match@>=1.0.0 <2.0.0",
                                   "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+                                  "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
                                   "optional": true
                                 },
                                 "concat-map": {
                                   "version": "0.0.1",
-                                  "from": "concat-map@0.0.1",
                                   "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+                                  "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
                                   "optional": true
                                 }
                               }
@@ -4250,20 +5867,23 @@
                         },
                         "once": {
                           "version": "1.4.0",
-                          "from": "once@>=1.3.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+                          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+                          "requires": {
+                            "wrappy": "1"
+                          },
                           "dependencies": {
                             "wrappy": {
                               "version": "1.0.2",
-                              "from": "wrappy@>=1.0.0 <2.0.0",
-                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+                              "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+                              "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
                             }
                           }
                         },
                         "path-is-absolute": {
                           "version": "1.0.1",
-                          "from": "path-is-absolute@>=1.0.0 <2.0.0",
                           "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+                          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
                           "optional": true
                         }
                       }
@@ -4274,73 +5894,103 @@
             },
             "safe-json-stringify": {
               "version": "1.0.4",
-              "from": "safe-json-stringify@>=1.0.0 <2.0.0",
               "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.0.4.tgz",
+              "integrity": "sha1-gaCY9Efku8P/MxKiQ1IbwGDvWRE=",
               "optional": true
             }
           }
         },
         "mongoose": {
           "version": "4.11.14",
-          "from": "mongoose@4.11.14",
           "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.14.tgz",
+          "integrity": "sha1-uFQCqvKMXD5FyO+T/mlUTqpdAPM=",
+          "requires": {
+            "async": "2.1.4",
+            "bson": "~1.0.4",
+            "hooks-fixed": "2.0.0",
+            "kareem": "1.5.0",
+            "mongodb": "2.2.31",
+            "mpath": "0.3.0",
+            "mpromise": "0.5.5",
+            "mquery": "2.3.2",
+            "ms": "2.0.0",
+            "muri": "1.2.2",
+            "regexp-clone": "0.0.1",
+            "sliced": "1.0.1"
+          },
           "dependencies": {
             "async": {
               "version": "2.1.4",
-              "from": "async@2.1.4",
               "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+              "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+              "requires": {
+                "lodash": "^4.14.0"
+              },
               "dependencies": {
                 "lodash": {
                   "version": "4.17.4",
-                  "from": "lodash@>=4.14.0 <5.0.0",
-                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz"
+                  "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+                  "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4="
                 }
               }
             },
             "bson": {
               "version": "1.0.4",
-              "from": "bson@>=1.0.4 <1.1.0",
-              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz"
+              "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.4.tgz",
+              "integrity": "sha1-k8ENOeqltYQVy8QFLz5T5WKwtyw="
             },
             "hooks-fixed": {
               "version": "2.0.0",
-              "from": "hooks-fixed@2.0.0",
-              "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+              "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
             },
             "kareem": {
               "version": "1.5.0",
-              "from": "kareem@1.5.0",
-              "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
+              "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+              "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
             },
             "mongodb": {
               "version": "2.2.31",
-              "from": "mongodb@2.2.31",
               "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz",
+              "integrity": "sha1-GUBEXGYeGSF7s7+CRdmFSq71SNs=",
+              "requires": {
+                "es6-promise": "3.2.1",
+                "mongodb-core": "2.1.15",
+                "readable-stream": "2.2.7"
+              },
               "dependencies": {
                 "es6-promise": {
                   "version": "3.2.1",
-                  "from": "es6-promise@3.2.1",
-                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+                  "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+                  "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
                 },
                 "mongodb-core": {
                   "version": "2.1.15",
-                  "from": "mongodb-core@2.1.15",
                   "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz",
+                  "integrity": "sha1-hB9TuH//9MdFgYnDXIroJ+EWl2Q=",
+                  "requires": {
+                    "bson": "~1.0.4",
+                    "require_optional": "~1.0.0"
+                  },
                   "dependencies": {
                     "require_optional": {
                       "version": "1.0.1",
-                      "from": "require_optional@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+                      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+                      "requires": {
+                        "resolve-from": "^2.0.0",
+                        "semver": "^5.1.0"
+                      },
                       "dependencies": {
                         "resolve-from": {
                           "version": "2.0.0",
-                          "from": "resolve-from@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+                          "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+                          "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
                         },
                         "semver": {
                           "version": "5.4.1",
-                          "from": "semver@>=5.1.0 <6.0.0",
-                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz"
+                          "resolved": "https://registry.npmjs.org/semver/-/semver-5.4.1.tgz",
+                          "integrity": "sha1-4FnAnYVx8FQII3M0M1BdOi8AsY4="
                         }
                       }
                     }
@@ -4348,50 +5998,62 @@
                 },
                 "readable-stream": {
                   "version": "2.2.7",
-                  "from": "readable-stream@2.2.7",
                   "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+                  "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+                  "requires": {
+                    "buffer-shims": "~1.0.0",
+                    "core-util-is": "~1.0.0",
+                    "inherits": "~2.0.1",
+                    "isarray": "~1.0.0",
+                    "process-nextick-args": "~1.0.6",
+                    "string_decoder": "~1.0.0",
+                    "util-deprecate": "~1.0.1"
+                  },
                   "dependencies": {
                     "buffer-shims": {
                       "version": "1.0.0",
-                      "from": "buffer-shims@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/buffer-shims/-/buffer-shims-1.0.0.tgz",
+                      "integrity": "sha1-mXjOMXOIxkmth5MCjDR37wRKi1E="
                     },
                     "core-util-is": {
                       "version": "1.0.2",
-                      "from": "core-util-is@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+                      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
                     },
                     "inherits": {
                       "version": "2.0.3",
-                      "from": "inherits@>=2.0.1 <2.1.0",
-                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+                      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+                      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
                     },
                     "isarray": {
                       "version": "1.0.0",
-                      "from": "isarray@>=1.0.0 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+                      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+                      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
                     },
                     "process-nextick-args": {
                       "version": "1.0.7",
-                      "from": "process-nextick-args@>=1.0.6 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+                      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+                      "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
                     },
                     "string_decoder": {
                       "version": "1.0.3",
-                      "from": "string_decoder@>=1.0.0 <1.1.0",
                       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+                      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+                      "requires": {
+                        "safe-buffer": "~5.1.0"
+                      },
                       "dependencies": {
                         "safe-buffer": {
                           "version": "5.1.1",
-                          "from": "safe-buffer@>=5.1.0 <5.2.0",
-                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
+                          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
+                          "integrity": "sha1-iTMSr2myEj3vcfV4iQAWce6yyFM="
                         }
                       }
                     },
                     "util-deprecate": {
                       "version": "1.0.2",
-                      "from": "util-deprecate@>=1.0.1 <1.1.0",
-                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+                      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+                      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
                     }
                   }
                 }
@@ -4399,1193 +6061,1679 @@
             },
             "mpath": {
               "version": "0.3.0",
-              "from": "mpath@0.3.0",
-              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
+              "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+              "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
             },
             "mpromise": {
               "version": "0.5.5",
-              "from": "mpromise@0.5.5",
-              "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
+              "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+              "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
             },
             "mquery": {
               "version": "2.3.2",
-              "from": "mquery@2.3.2",
               "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
+              "integrity": "sha1-4sYK0RfPCA8u+x7N0UTnu/+/yhE=",
+              "requires": {
+                "bluebird": "^3.5.0",
+                "debug": "^2.6.9",
+                "regexp-clone": "^0.0.1",
+                "sliced": "0.0.5"
+              },
               "dependencies": {
                 "bluebird": {
                   "version": "3.5.1",
-                  "from": "bluebird@>=3.5.0 <4.0.0",
-                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz"
+                  "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.1.tgz",
+                  "integrity": "sha1-2VUfnemPH82h5oPRfukaBgLuLrk="
                 },
                 "debug": {
                   "version": "2.6.9",
-                  "from": "debug@>=2.6.9 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+                  "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+                  "integrity": "sha1-XRKFFd8TT/Mn6QpMk/Tgd6U2NB8=",
+                  "requires": {
+                    "ms": "2.0.0"
+                  }
                 },
                 "sliced": {
                   "version": "0.0.5",
-                  "from": "sliced@0.0.5",
-                  "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+                  "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+                  "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
                 }
               }
             },
             "ms": {
               "version": "2.0.0",
-              "from": "ms@2.0.0",
-              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+              "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+              "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
             },
             "muri": {
               "version": "1.2.2",
-              "from": "muri@1.2.2",
-              "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz"
+              "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz",
+              "integrity": "sha1-YxmBMmUNsIoEzHnM0A3Tia/SYxw="
             },
             "regexp-clone": {
               "version": "0.0.1",
-              "from": "regexp-clone@0.0.1",
-              "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+              "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
             },
             "sliced": {
               "version": "1.0.1",
-              "from": "sliced@1.0.1",
-              "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+              "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+              "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
             }
           }
         },
         "underscore": {
           "version": "1.8.3",
-          "from": "underscore@1.8.3",
-          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz"
+          "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.3.tgz",
+          "integrity": "sha1-Tz+1OxBuYJf8+ctBCfKl6b36UCI="
         }
       }
     },
     "fhlog": {
       "version": "0.13.1",
-      "from": "fhlog@>=0.13.0 <0.14.0",
       "resolved": "https://registry.npmjs.org/fhlog/-/fhlog-0.13.1.tgz",
+      "integrity": "sha1-1/bREVj2hBrFps9ylukaFKNM0fU=",
+      "requires": {
+        "async": "~0.9.0",
+        "brfs": "~1.4.4",
+        "colors": "~1.0.3",
+        "html5-fs": "0.0.1",
+        "lodash": "~2.4.1",
+        "moment": "~2.19.3",
+        "safejson": "~1.0.0",
+        "xtend": "~4.0.0"
+      },
       "dependencies": {
         "async": {
           "version": "0.9.2",
-          "from": "async@>=0.9.0 <0.10.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-0.9.2.tgz",
+          "integrity": "sha1-rqdNXmHB+JlhO/ZL2mbUx48v0X0="
         },
         "lodash": {
           "version": "2.4.2",
-          "from": "lodash@>=2.4.1 <2.5.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz"
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-2.4.2.tgz",
+          "integrity": "sha1-+t2DS5aDBz2hebPq5tnA0VBT9z4="
         },
         "moment": {
           "version": "2.19.4",
-          "from": "moment@>=2.19.3 <2.20.0",
-          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz"
+          "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.4.tgz",
+          "integrity": "sha1-F+XixurYgZyOz62DoKzMsxLpRoI="
         }
       }
     },
     "finalhandler": {
       "version": "1.1.1",
-      "from": "finalhandler@1.1.1",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.1.tgz",
+      "integrity": "sha512-Y1GUDo39ez4aHAw7MysnUD5JzYX+WaIj8I57kO3aEPT1fFRL4sr7mjei97FgnwhAyyzRYmQZaTHb2+9uZ1dPtg==",
+      "requires": {
+        "debug": "2.6.9",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "on-finished": "~2.3.0",
+        "parseurl": "~1.3.2",
+        "statuses": "~1.4.0",
+        "unpipe": "~1.0.0"
+      },
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@~1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "foreach": {
       "version": "2.0.5",
-      "from": "foreach@>=2.0.5 <3.0.0",
-      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/foreach/-/foreach-2.0.5.tgz",
+      "integrity": "sha1-C+4AUBiusmDQo6865ljdATbsG5k="
     },
     "forever-agent": {
       "version": "0.6.1",
-      "from": "forever-agent@>=0.6.1 <0.7.0",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
+      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
     },
     "form-data": {
       "version": "2.3.2",
-      "from": "form-data@>=2.3.1 <2.4.0",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.2.tgz",
+      "integrity": "sha1-SXBJi+YEwgwAXU9cI67NIda0kJk=",
+      "requires": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "1.0.6",
+        "mime-types": "^2.1.12"
+      }
     },
     "forwarded": {
       "version": "0.1.2",
-      "from": "forwarded@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.1.2.tgz",
+      "integrity": "sha1-mMI9qxF1ZXuMBXPozszZGw/xjIQ="
     },
     "fresh": {
       "version": "0.5.2",
-      "from": "fresh@0.5.2",
-      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha1-PYyt2Q2XZWn6g1qx+OSyOhBWBac="
     },
     "fs-constants": {
       "version": "1.0.0",
-      "from": "fs-constants@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha1-a+Dem+mYzhavivwkSXue6bfM2a0="
     },
     "fs-extra": {
       "version": "1.0.0",
-      "from": "fs-extra@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-1.0.0.tgz",
+      "integrity": "sha1-zTzl9+fLYUWIP8rjGR6Yd/hYeVA=",
+      "requires": {
+        "graceful-fs": "^4.1.2",
+        "jsonfile": "^2.1.0",
+        "klaw": "^1.0.0"
+      }
     },
     "fs.realpath": {
       "version": "1.0.0",
-      "from": "fs.realpath@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "function-bind": {
       "version": "1.1.1",
-      "from": "function-bind@>=1.1.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha1-pWiZ0+o8m6uHS7l3O3xe3pL0iV0="
     },
     "getpass": {
       "version": "0.1.7",
-      "from": "getpass@>=0.1.1 <0.2.0",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
+      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+      "requires": {
+        "assert-plus": "^1.0.0"
+      }
     },
     "glob": {
       "version": "7.1.2",
-      "from": "glob@>=7.0.0 <8.0.0",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
+      "integrity": "sha1-wZyd+aAocC1nhhI4SmVSQExjbRU=",
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
     },
     "graceful-fs": {
       "version": "4.1.11",
-      "from": "graceful-fs@>=4.1.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz"
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.11.tgz",
+      "integrity": "sha1-Dovf5NHduIVNZOBOp8AOKgJuVlg="
     },
     "handlebars": {
       "version": "4.0.6",
-      "from": "handlebars@4.0.6",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.0.6.tgz",
+      "integrity": "sha1-LORISFBTf5yXqAJtU5m5NcTtTtc=",
+      "requires": {
+        "async": "^1.4.0",
+        "optimist": "^0.6.1",
+        "source-map": "^0.4.4",
+        "uglify-js": "^2.6"
+      }
     },
     "har-schema": {
       "version": "2.0.0",
-      "from": "har-schema@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
+      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
     },
     "har-validator": {
       "version": "5.0.3",
-      "from": "har-validator@>=5.0.3 <5.1.0",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz",
+      "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
+      "requires": {
+        "ajv": "^5.1.0",
+        "har-schema": "^2.0.0"
+      }
     },
     "has": {
       "version": "1.0.3",
-      "from": "has@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha1-ci18v8H2qoJB8W3YFOAR4fQeh5Y=",
+      "requires": {
+        "function-bind": "^1.1.1"
+      }
     },
     "hasha": {
       "version": "2.2.0",
-      "from": "hasha@>=2.2.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/hasha/-/hasha-2.2.0.tgz",
+      "integrity": "sha1-eNfL/B5tZjA/55g3NlmEUXsvbuE=",
+      "requires": {
+        "is-stream": "^1.0.1",
+        "pinkie-promise": "^2.0.0"
+      }
     },
     "hawk": {
       "version": "6.0.2",
-      "from": "hawk@>=6.0.2 <6.1.0",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
+      "integrity": "sha1-r02RTrBl+bXOTZ0RwcshJu7MMDg=",
+      "requires": {
+        "boom": "4.x.x",
+        "cryptiles": "3.x.x",
+        "hoek": "4.x.x",
+        "sntp": "2.x.x"
+      }
     },
     "hoek": {
       "version": "4.2.1",
-      "from": "hoek@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
+      "integrity": "sha1-ljRQKqEsRF3Vp8VzS1cruHOKrLs="
     },
     "hooks-fixed": {
       "version": "2.0.0",
-      "from": "hooks-fixed@2.0.0",
-      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/hooks-fixed/-/hooks-fixed-2.0.0.tgz",
+      "integrity": "sha1-oB2JTVKsf2WZu7H2PfycQR33DLo="
     },
     "html5-fs": {
       "version": "0.0.1",
-      "from": "html5-fs@0.0.1",
-      "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/html5-fs/-/html5-fs-0.0.1.tgz",
+      "integrity": "sha1-Ly17oI2hzAdtIP6JZp6lCURk9aQ="
     },
     "http-errors": {
       "version": "1.6.3",
-      "from": "http-errors@>=1.6.2 <1.7.0",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz"
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.3.tgz",
+      "integrity": "sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=",
+      "requires": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.3",
+        "setprototypeof": "1.1.0",
+        "statuses": ">= 1.4.0 < 2"
+      }
     },
     "http-signature": {
       "version": "1.2.0",
-      "from": "http-signature@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
+      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "jsprim": "^1.2.2",
+        "sshpk": "^1.7.0"
+      }
     },
     "human-interval": {
       "version": "0.1.6",
-      "from": "human-interval@>=0.1.3 <0.2.0",
-      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/human-interval/-/human-interval-0.1.6.tgz",
+      "integrity": "sha1-AFeXNFR2TDq8vrKu1hL8lkTmhIg="
     },
     "iconv-lite": {
       "version": "0.4.19",
-      "from": "iconv-lite@0.4.19",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz"
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
+      "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
     },
     "inflight": {
       "version": "1.0.6",
-      "from": "inflight@>=1.0.4 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
     },
     "inherits": {
       "version": "2.0.3",
-      "from": "inherits@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "ipaddr.js": {
       "version": "1.6.0",
-      "from": "ipaddr.js@1.6.0",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.6.0.tgz",
+      "integrity": "sha1-4/o1e3c9phnybpXwSdBVxyeW+Gs="
     },
     "is-buffer": {
       "version": "1.1.6",
-      "from": "is-buffer@>=1.1.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha1-76ouqdqg16suoTqXsritUf776L4="
     },
     "is-stream": {
       "version": "1.1.0",
-      "from": "is-stream@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-1.1.0.tgz",
+      "integrity": "sha1-EtSj3U5o4Lec6428hBc66A2RykQ="
     },
     "is-typedarray": {
       "version": "1.0.0",
-      "from": "is-typedarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
+      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
     },
     "isarray": {
       "version": "1.0.0",
-      "from": "isarray@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
-      "from": "isexe@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA="
     },
     "isstream": {
       "version": "0.1.2",
-      "from": "isstream@>=0.1.2 <0.2.0",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
+      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+    },
+    "jsbn": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
+      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+      "optional": true
     },
     "json-schema": {
       "version": "0.2.3",
-      "from": "json-schema@0.2.3",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
+      "integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
     },
     "json-schema-traverse": {
       "version": "0.3.1",
-      "from": "json-schema-traverse@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz",
+      "integrity": "sha1-NJptRMU6Ud6JtAgFxdXlm0F9M0A="
     },
     "json-stringify-safe": {
       "version": "5.0.1",
-      "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "jsonfile": {
       "version": "2.4.0",
-      "from": "jsonfile@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-2.4.0.tgz",
+      "integrity": "sha1-NzaitCi4e72gzIO1P6PWM6NcKug=",
+      "requires": {
+        "graceful-fs": "^4.1.6"
+      }
     },
     "jsprim": {
       "version": "1.4.1",
-      "from": "jsprim@>=1.2.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
+      "integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+      "requires": {
+        "assert-plus": "1.0.0",
+        "extsprintf": "1.3.0",
+        "json-schema": "0.2.3",
+        "verror": "1.10.0"
+      }
     },
     "kareem": {
       "version": "1.5.0",
-      "from": "kareem@1.5.0",
-      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-1.5.0.tgz",
+      "integrity": "sha1-4+QQHZ3P3imXadr0tNtk2JXRdEg="
     },
     "kew": {
       "version": "0.7.0",
-      "from": "kew@>=0.7.0 <0.8.0",
-      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
+      "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz",
+      "integrity": "sha1-edk9LTM2PW/dKXCzNdkUGtWR15s="
     },
     "kind-of": {
       "version": "3.2.2",
-      "from": "kind-of@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
+      "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
+      "requires": {
+        "is-buffer": "^1.1.5"
+      }
     },
     "klaw": {
       "version": "1.3.1",
-      "from": "klaw@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz",
+      "integrity": "sha1-QIhDO0azsbolnXh4XY6W9zugJDk=",
+      "requires": {
+        "graceful-fs": "^4.1.9"
+      }
     },
     "lazy-cache": {
       "version": "1.0.4",
-      "from": "lazy-cache@>=1.0.3 <2.0.0",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "integrity": "sha1-odePw6UEdMuAhF07O24dpJpEbo4=",
       "optional": true
     },
     "lazystream": {
       "version": "1.0.0",
-      "from": "lazystream@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/lazystream/-/lazystream-1.0.0.tgz",
+      "integrity": "sha1-9plf4PggOS9hOWvolGJAe7dxaOQ=",
+      "requires": {
+        "readable-stream": "^2.0.5"
+      }
     },
     "levn": {
       "version": "0.3.0",
-      "from": "levn@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
     },
     "lodash": {
       "version": "4.17.10",
-      "from": "lodash@>=4.8.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz"
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.10.tgz",
+      "integrity": "sha1-G3eTz3JZ6jj7NmHU04syYK+K5Oc="
     },
     "lodash.assign": {
       "version": "4.2.0",
-      "from": "lodash.assign@>=4.2.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.assign/-/lodash.assign-4.2.0.tgz",
+      "integrity": "sha1-DZnzzNem0mHRm9rrkkUAXShYCOc="
     },
     "lodash.clone": {
       "version": "4.5.0",
-      "from": "lodash.clone@>=4.5.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.clone/-/lodash.clone-4.5.0.tgz",
+      "integrity": "sha1-GVhwRQ9aExkkeN9Lw9I9LeoZB7Y="
     },
     "lodash.has": {
       "version": "4.5.2",
-      "from": "lodash.has@>=4.5.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.has/-/lodash.has-4.5.2.tgz",
+      "integrity": "sha1-0Z9NwQlQWMzL4rDN9O4P5Ko3yGI="
     },
     "lodash.isobject": {
       "version": "3.0.2",
-      "from": "lodash.isobject@>=3.0.2 <4.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.isobject/-/lodash.isobject-3.0.2.tgz",
+      "integrity": "sha1-PI+41bW/S/kK4G4U8qUwpO2TXh0="
     },
     "lodash.set": {
       "version": "4.3.2",
-      "from": "lodash.set@>=4.3.2 <5.0.0",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+      "integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
     },
     "longest": {
       "version": "1.0.1",
-      "from": "longest@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
+      "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc="
     },
     "lru-cache": {
       "version": "4.1.3",
-      "from": "lru-cache@>=4.1.0 <4.2.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz"
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha1-oRdc80lt/IQ2wVbDNLSVWZK85pw=",
+      "requires": {
+        "pseudomap": "^1.0.2",
+        "yallist": "^2.1.2"
+      }
     },
     "magic-string": {
       "version": "0.22.5",
-      "from": "magic-string@>=0.22.4 <0.23.0",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz"
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.22.5.tgz",
+      "integrity": "sha1-jpz1r930Q4XB2lvCpqDb0QsDZX4=",
+      "requires": {
+        "vlq": "^0.2.2"
+      }
     },
     "media-typer": {
       "version": "0.3.0",
-      "from": "media-typer@0.3.0",
-      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
     "merge-descriptors": {
       "version": "1.0.1",
-      "from": "merge-descriptors@1.0.1",
-      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.1.tgz",
+      "integrity": "sha1-sAqqVW3YtEVoFQ7J0blT8/kMu2E="
     },
     "merge-source-map": {
       "version": "1.0.4",
-      "from": "merge-source-map@1.0.4",
       "resolved": "https://registry.npmjs.org/merge-source-map/-/merge-source-map-1.0.4.tgz",
+      "integrity": "sha1-pd5GU42uhNQRTMXqArR3KmNGcB8=",
+      "requires": {
+        "source-map": "^0.5.6"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@>=0.5.6 <0.6.0",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz"
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
         }
       }
     },
     "methods": {
       "version": "1.1.2",
-      "from": "methods@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha1-VSmk1nZUE07cxSZmVoNbD4Ua/O4="
     },
     "mime": {
       "version": "1.4.1",
-      "from": "mime@1.4.1",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.4.1.tgz",
+      "integrity": "sha1-Eh+evEnjdm8xGnbh+hyAA8SwOqY="
     },
     "mime-db": {
       "version": "1.33.0",
-      "from": "mime-db@>=1.33.0 <1.34.0",
-      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz"
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.33.0.tgz",
+      "integrity": "sha1-o0kgUKXLm2NFBUHjnZeI0icng9s="
     },
     "mime-types": {
       "version": "2.1.18",
-      "from": "mime-types@>=2.1.18 <2.2.0",
-      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz"
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.18.tgz",
+      "integrity": "sha1-bzI/YKg9ERRvgx/xH9ZuL+VQO7g=",
+      "requires": {
+        "mime-db": "~1.33.0"
+      }
     },
     "minimatch": {
       "version": "3.0.4",
-      "from": "minimatch@>=3.0.4 <4.0.0",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha1-UWbihkV/AzBgZL5Ul+jbsMPTIIM=",
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
     },
     "minimist": {
       "version": "0.0.8",
-      "from": "minimist@0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz"
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
     },
     "mkdirp": {
       "version": "0.5.1",
-      "from": "mkdirp@0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      }
     },
     "mmmagic": {
       "version": "0.4.6",
-      "from": "mmmagic@>=0.4.1 <0.5.0",
-      "resolved": "https://registry.npmjs.org/mmmagic/-/mmmagic-0.4.6.tgz"
+      "resolved": "https://registry.npmjs.org/mmmagic/-/mmmagic-0.4.6.tgz",
+      "integrity": "sha1-XivLiMRAgWS3eTIznLQybbN68jU=",
+      "requires": {
+        "nan": "^2.4.0"
+      }
     },
     "moment": {
       "version": "2.22.2",
-      "from": "moment@>=2.10.6 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.22.2.tgz",
+      "integrity": "sha1-PCV/mDn8DpP/UxSWMiOeuQeD/2Y="
     },
     "moment-timezone": {
       "version": "0.5.17",
-      "from": "moment-timezone@>=0.5.0 <0.6.0",
-      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz"
+      "resolved": "https://registry.npmjs.org/moment-timezone/-/moment-timezone-0.5.17.tgz",
+      "integrity": "sha1-PI/vMgUdhMOvF02R3FKXfcsK1+U=",
+      "requires": {
+        "moment": ">= 2.9.0"
+      }
     },
     "mongodb": {
       "version": "2.2.35",
-      "from": "mongodb@2.2.35",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
+      "resolved": "http://registry.npmjs.org/mongodb/-/mongodb-2.2.35.tgz",
+      "integrity": "sha512-3HGLucDg/8EeYMin3k+nFWChTA85hcYDCw1lPsWR6yV9A6RgKb24BkLiZ9ySZR+S0nfBjWoIUS7cyV6ceGx5Gg==",
+      "requires": {
+        "es6-promise": "3.2.1",
+        "mongodb-core": "2.1.19",
+        "readable-stream": "2.2.7"
+      },
       "dependencies": {
         "bson": {
           "version": "1.0.9",
-          "from": "bson@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz"
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
         },
         "es6-promise": {
           "version": "3.2.1",
-          "from": "es6-promise@3.2.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "mongodb-core": {
           "version": "2.1.19",
-          "from": "mongodb-core@2.1.19",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz"
+          "resolved": "http://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.19.tgz",
+          "integrity": "sha512-Jt4AtWUkpuW03kRdYGxga4O65O1UHlFfvvInslEfLlGi+zDMxbBe3J2NVmN9qPJ957Mn6Iz0UpMtV80cmxCVxw==",
+          "requires": {
+            "bson": "~1.0.4",
+            "require_optional": "~1.0.0"
+          }
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
           "version": "2.2.7",
-          "from": "readable-stream@2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
     "mongodb-core": {
       "version": "1.3.10",
-      "from": "mongodb-core@1.3.10",
-      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.10.tgz"
+      "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-1.3.10.tgz",
+      "integrity": "sha1-Ud3Ov56c/9BX+C8pI82qwGzzIBs=",
+      "requires": {
+        "bson": "~0.4.21",
+        "require_optional": "~1.0.0"
+      }
     },
     "mongodb-uri": {
       "version": "0.9.7",
-      "from": "mongodb-uri@0.9.7",
-      "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz"
+      "resolved": "https://registry.npmjs.org/mongodb-uri/-/mongodb-uri-0.9.7.tgz",
+      "integrity": "sha1-D3ca0W9IOuZfQoeWlCjp+8SqYYE="
     },
     "mongoose": {
       "version": "4.11.14",
-      "from": "mongoose@4.11.14",
       "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-4.11.14.tgz",
+      "integrity": "sha1-uFQCqvKMXD5FyO+T/mlUTqpdAPM=",
+      "requires": {
+        "async": "2.1.4",
+        "bson": "~1.0.4",
+        "hooks-fixed": "2.0.0",
+        "kareem": "1.5.0",
+        "mongodb": "2.2.31",
+        "mpath": "0.3.0",
+        "mpromise": "0.5.5",
+        "mquery": "2.3.2",
+        "ms": "2.0.0",
+        "muri": "1.2.2",
+        "regexp-clone": "0.0.1",
+        "sliced": "1.0.1"
+      },
       "dependencies": {
         "async": {
           "version": "2.1.4",
-          "from": "async@2.1.4",
-          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-2.1.4.tgz",
+          "integrity": "sha1-LSFgx3iAMuTdbL4lAvH5osj2zeQ=",
+          "requires": {
+            "lodash": "^4.14.0"
+          }
         },
         "bson": {
           "version": "1.0.9",
-          "from": "bson@>=1.0.4 <1.1.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz"
+          "resolved": "https://registry.npmjs.org/bson/-/bson-1.0.9.tgz",
+          "integrity": "sha512-IQX9/h7WdMBIW/q/++tGd+emQr0XMdeZ6icnT/74Xk9fnabWn+gZgpE+9V+gujL3hhJOoNrnDVY7tWdzc7NUTg=="
         },
         "es6-promise": {
           "version": "3.2.1",
-          "from": "es6-promise@3.2.1",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz"
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.2.1.tgz",
+          "integrity": "sha1-7FYjOGgDKQkgcXDDlEjiREndH8Q="
         },
         "mongodb": {
           "version": "2.2.31",
-          "from": "mongodb@2.2.31",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz"
+          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-2.2.31.tgz",
+          "integrity": "sha1-GUBEXGYeGSF7s7+CRdmFSq71SNs=",
+          "requires": {
+            "es6-promise": "3.2.1",
+            "mongodb-core": "2.1.15",
+            "readable-stream": "2.2.7"
+          }
         },
         "mongodb-core": {
           "version": "2.1.15",
-          "from": "mongodb-core@2.1.15",
-          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz"
+          "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-2.1.15.tgz",
+          "integrity": "sha1-hB9TuH//9MdFgYnDXIroJ+EWl2Q=",
+          "requires": {
+            "bson": "~1.0.4",
+            "require_optional": "~1.0.0"
+          }
         },
         "process-nextick-args": {
           "version": "1.0.7",
-          "from": "process-nextick-args@>=1.0.6 <1.1.0",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz"
+          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
+          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M="
         },
         "readable-stream": {
           "version": "2.2.7",
-          "from": "readable-stream@2.2.7",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.2.7.tgz",
+          "integrity": "sha1-BwV6y+JGeyIELTb5jFrVBwVOlbE=",
+          "requires": {
+            "buffer-shims": "~1.0.0",
+            "core-util-is": "~1.0.0",
+            "inherits": "~2.0.1",
+            "isarray": "~1.0.0",
+            "process-nextick-args": "~1.0.6",
+            "string_decoder": "~1.0.0",
+            "util-deprecate": "~1.0.1"
+          }
         },
         "string_decoder": {
           "version": "1.0.3",
-          "from": "string_decoder@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
+          "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+          "requires": {
+            "safe-buffer": "~5.1.0"
+          }
         }
       }
     },
     "mongoose-paginate": {
       "version": "5.0.3",
-      "from": "mongoose-paginate@5.0.3",
       "resolved": "https://registry.npmjs.org/mongoose-paginate/-/mongoose-paginate-5.0.3.tgz",
+      "integrity": "sha1-165J7Vv2Tx9692IOqGW2cFjFU3E=",
+      "requires": {
+        "bluebird": "3.0.5"
+      },
       "dependencies": {
         "bluebird": {
           "version": "3.0.5",
-          "from": "bluebird@3.0.5",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.0.5.tgz",
+          "integrity": "sha1-L/nQfJs+2ynW0oD+B1KDZefs05I="
         }
       }
     },
     "mongoose-timestamp": {
       "version": "0.3.0",
-      "from": "mongoose-timestamp@0.3.0",
-      "resolved": "https://registry.npmjs.org/mongoose-timestamp/-/mongoose-timestamp-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/mongoose-timestamp/-/mongoose-timestamp-0.3.0.tgz",
+      "integrity": "sha1-+zCmUfFFzQOFmama2Ow0FBB4k1k="
     },
     "mpath": {
       "version": "0.3.0",
-      "from": "mpath@0.3.0",
-      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.3.0.tgz",
+      "integrity": "sha1-elj3iem1/TyUUgY0FXlg8mvV70Q="
     },
     "mpromise": {
       "version": "0.5.5",
-      "from": "mpromise@0.5.5",
-      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz"
+      "resolved": "https://registry.npmjs.org/mpromise/-/mpromise-0.5.5.tgz",
+      "integrity": "sha1-9bJCWddjrMIlewoMjG2Gb9UXMuY="
     },
     "mquery": {
       "version": "2.3.2",
-      "from": "mquery@2.3.2",
       "resolved": "https://registry.npmjs.org/mquery/-/mquery-2.3.2.tgz",
+      "integrity": "sha1-4sYK0RfPCA8u+x7N0UTnu/+/yhE=",
+      "requires": {
+        "bluebird": "^3.5.0",
+        "debug": "^2.6.9",
+        "regexp-clone": "^0.0.1",
+        "sliced": "0.0.5"
+      },
       "dependencies": {
         "sliced": {
           "version": "0.0.5",
-          "from": "sliced@0.0.5",
-          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz"
+          "resolved": "https://registry.npmjs.org/sliced/-/sliced-0.0.5.tgz",
+          "integrity": "sha1-XtwETKTrb3gW1Qui/GPiXY/kcH8="
         }
       }
     },
     "ms": {
       "version": "2.0.0",
-      "from": "ms@2.0.0",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "multer": {
       "version": "0.1.8",
-      "from": "multer@0.1.8",
-      "resolved": "https://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+      "resolved": "http://registry.npmjs.org/multer/-/multer-0.1.8.tgz",
+      "integrity": "sha1-VRuKYBUJNwG8rMlkkWsa4GV483s=",
+      "requires": {
+        "busboy": "~0.2.9",
+        "mkdirp": "~0.3.5",
+        "qs": "~1.2.2",
+        "type-is": "~1.5.2"
+      },
       "dependencies": {
         "mime-db": {
           "version": "1.12.0",
-          "from": "mime-db@>=1.12.0 <1.13.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz"
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.12.0.tgz",
+          "integrity": "sha1-PQxjGA9FjrENMlqqN9fFiuMS6dc="
         },
         "mime-types": {
           "version": "2.0.14",
-          "from": "mime-types@>=2.0.9 <2.1.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz"
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.0.14.tgz",
+          "integrity": "sha1-MQ4VnbI+B3+Lsit0jav6SVcUCqY=",
+          "requires": {
+            "mime-db": "~1.12.0"
+          }
         },
         "mkdirp": {
           "version": "0.3.5",
-          "from": "mkdirp@>=0.3.5 <0.4.0",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz"
+          "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.3.5.tgz",
+          "integrity": "sha1-3j5fiWHIjHh+4TaN+EmsRBPsqNc="
         },
         "qs": {
           "version": "1.2.2",
-          "from": "qs@>=1.2.2 <1.3.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz"
+          "resolved": "https://registry.npmjs.org/qs/-/qs-1.2.2.tgz",
+          "integrity": "sha1-GbV/8k3CqZzh+L32r82ln472H4g="
         },
         "type-is": {
           "version": "1.5.7",
-          "from": "type-is@>=1.5.2 <1.6.0",
-          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz"
+          "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.5.7.tgz",
+          "integrity": "sha1-uTaKWTzG730GReeLL0xky+zQXpA=",
+          "requires": {
+            "media-typer": "0.3.0",
+            "mime-types": "~2.0.9"
+          }
         }
       }
     },
     "muri": {
       "version": "1.2.2",
-      "from": "muri@1.2.2",
-      "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz"
+      "resolved": "https://registry.npmjs.org/muri/-/muri-1.2.2.tgz",
+      "integrity": "sha1-YxmBMmUNsIoEzHnM0A3Tia/SYxw="
     },
     "mv": {
       "version": "2.1.1",
-      "from": "mv@>=2.0.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/mv/-/mv-2.1.1.tgz",
+      "integrity": "sha1-rmzg1vbV4KT32JN5jQPB6pVZtqI=",
       "optional": true,
+      "requires": {
+        "mkdirp": "~0.5.1",
+        "ncp": "~2.0.0",
+        "rimraf": "~2.4.0"
+      },
       "dependencies": {
         "glob": {
           "version": "6.0.4",
-          "from": "glob@>=6.0.1 <7.0.0",
           "resolved": "https://registry.npmjs.org/glob/-/glob-6.0.4.tgz",
-          "optional": true
+          "integrity": "sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=",
+          "optional": true,
+          "requires": {
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "2 || 3",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
         },
         "rimraf": {
           "version": "2.4.5",
-          "from": "rimraf@>=2.4.0 <2.5.0",
           "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-          "optional": true
+          "integrity": "sha1-7nEM5dk6j9uFb7Xqj/Di11k0sto=",
+          "optional": true,
+          "requires": {
+            "glob": "^6.0.1"
+          }
         }
       }
     },
     "nan": {
       "version": "2.10.0",
-      "from": "nan@>=2.10.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.10.0.tgz",
+      "integrity": "sha1-ltDNYQ69WNS03pzAxoKM2pnHVI8="
     },
     "ncp": {
       "version": "2.0.0",
-      "from": "ncp@>=2.0.0 <2.1.0",
       "resolved": "https://registry.npmjs.org/ncp/-/ncp-2.0.0.tgz",
+      "integrity": "sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=",
       "optional": true
     },
     "negotiator": {
       "version": "0.6.1",
-      "from": "negotiator@0.6.1",
-      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.1.tgz",
+      "integrity": "sha1-KzJxhOiZIQEXeyhWP7XnECrNDKk="
     },
     "normalize-path": {
       "version": "2.1.1",
-      "from": "normalize-path@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
+      "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
+      "requires": {
+        "remove-trailing-separator": "^1.0.1"
+      }
     },
     "oauth-sign": {
       "version": "0.8.2",
-      "from": "oauth-sign@>=0.8.2 <0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
+      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz",
+      "integrity": "sha1-Rqarfwrq2N6unsBWV4C31O/rnUM="
     },
     "object-inspect": {
       "version": "1.4.1",
-      "from": "object-inspect@>=1.4.0 <1.5.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.4.1.tgz",
+      "integrity": "sha1-N/+xDnGtrzdI0F9xO0yUUvQCy8Q="
     },
     "object-keys": {
       "version": "1.0.12",
-      "from": "object-keys@>=1.0.6 <2.0.0",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz"
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag=="
     },
     "on-finished": {
       "version": "2.3.0",
-      "from": "on-finished@>=2.3.0 <2.4.0",
-      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.3.0.tgz",
+      "integrity": "sha1-IPEzZIGwg811M3mSoWlxqi2QaUc=",
+      "requires": {
+        "ee-first": "1.1.1"
+      }
     },
     "once": {
       "version": "1.4.0",
-      "from": "once@>=1.3.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz"
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "requires": {
+        "wrappy": "1"
+      }
     },
     "optimist": {
       "version": "0.6.1",
-      "from": "optimist@0.6.1",
-      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
+      "integrity": "sha1-2j6nRob6IaGaERwybpDrFaAZZoY=",
+      "requires": {
+        "minimist": "~0.0.1",
+        "wordwrap": "~0.0.2"
+      }
     },
     "optionator": {
       "version": "0.8.2",
-      "from": "optionator@>=0.8.1 <0.9.0",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      },
       "dependencies": {
         "wordwrap": {
           "version": "1.0.0",
-          "from": "wordwrap@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+          "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
         }
       }
     },
     "os-tmpdir": {
       "version": "1.0.2",
-      "from": "os-tmpdir@>=1.0.2 <1.1.0",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
     },
     "parseurl": {
       "version": "1.3.2",
-      "from": "parseurl@>=1.3.2 <1.4.0",
-      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.2.tgz",
+      "integrity": "sha1-/CidTtiZMRlGDBViUyYs3I3mW/M="
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "from": "path-is-absolute@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-parse": {
       "version": "1.0.5",
-      "from": "path-parse@>=1.0.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
+      "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME="
     },
     "path-to-regexp": {
       "version": "0.1.7",
-      "from": "path-to-regexp@0.1.7",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz"
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
+      "integrity": "sha1-32BBeABfUi8V60SQ5yR6G/qmf4w="
     },
     "pend": {
       "version": "1.2.0",
-      "from": "pend@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
+      "integrity": "sha1-elfrVQpng/kRUzH89GY9XI4AelA="
     },
     "performance-now": {
       "version": "2.1.0",
-      "from": "performance-now@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
+      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
     },
     "phantom": {
       "version": "4.0.12",
-      "from": "phantom@4.0.12",
-      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz"
+      "resolved": "https://registry.npmjs.org/phantom/-/phantom-4.0.12.tgz",
+      "integrity": "sha1-eNGM8/Knb+pJCfYWD8q/J0LX2/A=",
+      "requires": {
+        "phantomjs-prebuilt": "^2.1.16",
+        "split": "^1.0.1",
+        "winston": "^2.4.0"
+      }
     },
     "phantomjs-prebuilt": {
       "version": "2.1.16",
-      "from": "phantomjs-prebuilt@>=2.1.16 <3.0.0",
       "resolved": "https://registry.npmjs.org/phantomjs-prebuilt/-/phantomjs-prebuilt-2.1.16.tgz",
+      "integrity": "sha1-79ISpKOWbTZHaE6ouniFSb4q7+8=",
+      "requires": {
+        "es6-promise": "^4.0.3",
+        "extract-zip": "^1.6.5",
+        "fs-extra": "^1.0.0",
+        "hasha": "^2.2.0",
+        "kew": "^0.7.0",
+        "progress": "^1.1.8",
+        "request": "^2.81.0",
+        "request-progress": "^2.0.1",
+        "which": "^1.2.10"
+      },
       "dependencies": {
         "es6-promise": {
           "version": "4.2.4",
-          "from": "es6-promise@>=4.0.3 <5.0.0",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz"
+          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.4.tgz",
+          "integrity": "sha1-3EIhwrFlGHYL2MOaUtjzVvwA7Sk="
         }
       }
     },
     "pinkie": {
       "version": "2.0.4",
-      "from": "pinkie@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz",
+      "integrity": "sha1-clVrgM+g1IqXToDnckjoDtT3+HA="
     },
     "pinkie-promise": {
       "version": "2.0.1",
-      "from": "pinkie-promise@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
+      "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
+      "requires": {
+        "pinkie": "^2.0.0"
+      }
     },
     "prelude-ls": {
       "version": "1.1.2",
-      "from": "prelude-ls@>=1.1.2 <1.2.0",
-      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
     },
     "process-nextick-args": {
       "version": "2.0.0",
-      "from": "process-nextick-args@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
+      "integrity": "sha1-o31zL0JxtKsa0HDTVQjoKQeI/6o="
     },
     "progress": {
       "version": "1.1.8",
-      "from": "progress@>=1.1.8 <2.0.0",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz"
+      "resolved": "https://registry.npmjs.org/progress/-/progress-1.1.8.tgz",
+      "integrity": "sha1-4mDHj2Fhzdmw5WzD4Khd4Xx6V74="
     },
     "proxy-addr": {
       "version": "2.0.3",
-      "from": "proxy-addr@>=2.0.2 <2.1.0",
-      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.3.tgz",
+      "integrity": "sha1-NV8mJQWmIWRrMTCnKOtkfiIFU0E=",
+      "requires": {
+        "forwarded": "~0.1.2",
+        "ipaddr.js": "1.6.0"
+      }
     },
     "pseudomap": {
       "version": "1.0.2",
-      "from": "pseudomap@>=1.0.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/pseudomap/-/pseudomap-1.0.2.tgz",
+      "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM="
     },
     "punycode": {
       "version": "1.4.1",
-      "from": "punycode@>=1.4.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+      "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
     },
     "qs": {
       "version": "6.5.1",
-      "from": "qs@6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+      "integrity": "sha1-NJzfbu+J7EXBLX1es/wMhwNDptg="
     },
     "quote-stream": {
       "version": "1.0.2",
-      "from": "quote-stream@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/quote-stream/-/quote-stream-1.0.2.tgz",
+      "integrity": "sha1-hJY/jJwmuULhU/7rU6rnRlK34LI=",
+      "requires": {
+        "buffer-equal": "0.0.1",
+        "minimist": "^1.1.3",
+        "through2": "^2.0.0"
+      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.3 <2.0.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
         }
       }
     },
     "range-parser": {
       "version": "1.2.0",
-      "from": "range-parser@>=1.2.0 <1.3.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4="
     },
     "raw-body": {
       "version": "2.3.2",
-      "from": "raw-body@2.3.2",
       "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.3.2.tgz",
+      "integrity": "sha1-vNYMd9Prk83gBQKVw/N5OJvIj4k=",
+      "requires": {
+        "bytes": "3.0.0",
+        "http-errors": "1.6.2",
+        "iconv-lite": "0.4.19",
+        "unpipe": "1.0.0"
+      },
       "dependencies": {
         "depd": {
           "version": "1.1.1",
-          "from": "depd@1.1.1",
-          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz"
+          "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.1.tgz",
+          "integrity": "sha1-V4O04cRZ8G+lyif5kfPQbnoxA1k="
         },
         "http-errors": {
           "version": "1.6.2",
-          "from": "http-errors@1.6.2",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz"
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.6.2.tgz",
+          "integrity": "sha1-CgAsyFcHGSp+eUbO7cERVfYOxzY=",
+          "requires": {
+            "depd": "1.1.1",
+            "inherits": "2.0.3",
+            "setprototypeof": "1.0.3",
+            "statuses": ">= 1.3.1 < 2"
+          }
         },
         "setprototypeof": {
           "version": "1.0.3",
-          "from": "setprototypeof@1.0.3",
-          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz"
+          "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.0.3.tgz",
+          "integrity": "sha1-ZlZ+NwQ+608E2RvWWMDL77VbjgQ="
         }
       }
     },
     "readable-stream": {
       "version": "2.3.6",
-      "from": "readable-stream@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz"
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
+      "integrity": "sha1-sRwn2IuP8fvgcGQ8+UsMea4bCq8=",
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
     },
     "regexp-clone": {
       "version": "0.0.1",
-      "from": "regexp-clone@0.0.1",
-      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/regexp-clone/-/regexp-clone-0.0.1.tgz",
+      "integrity": "sha1-p8LgmJH9vzj7sQ03b7cwA+aKxYk="
     },
     "remove-trailing-separator": {
       "version": "1.1.0",
-      "from": "remove-trailing-separator@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
+      "integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8="
     },
     "repeat-string": {
       "version": "1.6.1",
-      "from": "repeat-string@>=1.5.2 <2.0.0",
-      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz",
+      "integrity": "sha1-jcrkcOHIirwtYA//Sndihtp15jc="
     },
     "request": {
       "version": "2.87.0",
-      "from": "request@2.87.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz"
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
+      "requires": {
+        "aws-sign2": "~0.7.0",
+        "aws4": "^1.6.0",
+        "caseless": "~0.12.0",
+        "combined-stream": "~1.0.5",
+        "extend": "~3.0.1",
+        "forever-agent": "~0.6.1",
+        "form-data": "~2.3.1",
+        "har-validator": "~5.0.3",
+        "http-signature": "~1.2.0",
+        "is-typedarray": "~1.0.0",
+        "isstream": "~0.1.2",
+        "json-stringify-safe": "~5.0.1",
+        "mime-types": "~2.1.17",
+        "oauth-sign": "~0.8.2",
+        "performance-now": "^2.1.0",
+        "qs": "~6.5.1",
+        "safe-buffer": "^5.1.1",
+        "tough-cookie": "~2.3.3",
+        "tunnel-agent": "^0.6.0",
+        "uuid": "^3.1.0"
+      }
     },
     "request-progress": {
       "version": "2.0.1",
-      "from": "request-progress@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/request-progress/-/request-progress-2.0.1.tgz",
+      "integrity": "sha1-XTa7V5YcZzqlt4jbyBQf3yO0Tgg=",
+      "requires": {
+        "throttleit": "^1.0.0"
+      }
     },
     "require_optional": {
       "version": "1.0.1",
-      "from": "require_optional@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+      "integrity": "sha1-TPNaQkf2TKPfjC7yCMxJSxyo/C4=",
+      "requires": {
+        "resolve-from": "^2.0.0",
+        "semver": "^5.1.0"
+      }
     },
     "resolve": {
       "version": "1.8.1",
-      "from": "resolve@>=1.1.5 <2.0.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz"
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
+      "requires": {
+        "path-parse": "^1.0.5"
+      }
     },
     "resolve-from": {
       "version": "2.0.0",
-      "from": "resolve-from@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+      "integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
     },
     "right-align": {
       "version": "0.1.3",
-      "from": "right-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
-      "optional": true
+      "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
+      "optional": true,
+      "requires": {
+        "align-text": "^0.1.1"
+      }
     },
     "rimraf": {
       "version": "2.6.2",
-      "from": "rimraf@2.6.2",
-      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz"
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
+      "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
+      "requires": {
+        "glob": "^7.0.5"
+      }
     },
     "safe-buffer": {
       "version": "5.1.2",
-      "from": "safe-buffer@>=5.1.1 <5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha1-mR7GnSluAxN0fVm9/St0XDX4go0="
     },
     "safe-json-stringify": {
       "version": "1.2.0",
-      "from": "safe-json-stringify@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/safe-json-stringify/-/safe-json-stringify-1.2.0.tgz",
+      "integrity": "sha1-NW5EvJjx+TzkXfFLzXwBzahuCv0=",
       "optional": true
     },
     "safejson": {
       "version": "1.0.1",
-      "from": "safejson@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/safejson/-/safejson-1.0.1.tgz",
+      "integrity": "sha1-W8u5UzuW/OEOY1b0IAF8FqT5yZg="
     },
     "safer-buffer": {
       "version": "2.1.2",
-      "from": "safer-buffer@>=2.0.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "semver": {
       "version": "5.5.0",
-      "from": "semver@>=5.1.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.0.tgz",
+      "integrity": "sha1-3Eu8emyp2Rbe5dQ1FvAJK1j3uKs="
     },
     "send": {
       "version": "0.16.2",
-      "from": "send@0.16.2",
       "resolved": "https://registry.npmjs.org/send/-/send-0.16.2.tgz",
+      "integrity": "sha512-E64YFPUssFHEFBvpbbjr44NCLtI1AohxQ8ZSiJjQLskAdKuriYEP6VyGEsRDH8ScozGpkaX1BGvhanqCwkcEZw==",
+      "requires": {
+        "debug": "2.6.9",
+        "depd": "~1.1.2",
+        "destroy": "~1.0.4",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "~1.6.2",
+        "mime": "1.4.1",
+        "ms": "2.0.0",
+        "on-finished": "~2.3.0",
+        "range-parser": "~1.2.0",
+        "statuses": "~1.4.0"
+      },
       "dependencies": {
         "statuses": {
           "version": "1.4.0",
-          "from": "statuses@~1.4.0",
-          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz"
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
+          "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
         }
       }
     },
     "serve-static": {
       "version": "1.13.2",
-      "from": "serve-static@1.13.2",
-      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz"
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.13.2.tgz",
+      "integrity": "sha512-p/tdJrO4U387R9oMjb1oj7qSMaMfmOyd4j9hOFoxZe2baQszgHcSWjuya/CiT5kgZZKRudHNOA0pYXOl8rQ5nw==",
+      "requires": {
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.2",
+        "send": "0.16.2"
+      }
     },
     "setprototypeof": {
       "version": "1.1.0",
-      "from": "setprototypeof@1.1.0",
-      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.1.0.tgz",
+      "integrity": "sha1-0L2FU2iHtv58DYGMuWLZ2RxU5lY="
     },
     "shallow-copy": {
       "version": "0.0.1",
-      "from": "shallow-copy@>=0.0.1 <0.1.0",
-      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
+      "integrity": "sha1-QV9CcC1z2BAzApLMXuhurhoRoXA="
     },
     "shimmer": {
       "version": "1.2.0",
-      "from": "shimmer@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.0.tgz",
+      "integrity": "sha1-+Wb3VVeJdj502IQRk2haXnhzZmU="
     },
     "sliced": {
       "version": "1.0.1",
-      "from": "sliced@1.0.1",
-      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/sliced/-/sliced-1.0.1.tgz",
+      "integrity": "sha1-CzpmK10Ewxd7GSa+qCsD+Dei70E="
     },
     "sntp": {
       "version": "2.1.0",
-      "from": "sntp@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
+      "integrity": "sha1-LGzsFP7cIiJznK+bXD2F0cxaLMg=",
+      "requires": {
+        "hoek": "4.x.x"
+      }
     },
     "source-map": {
       "version": "0.4.4",
-      "from": "source-map@>=0.4.4 <0.5.0",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz"
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.4.4.tgz",
+      "integrity": "sha1-66T12pwNyZneaAMti092FzZSA2s=",
+      "requires": {
+        "amdefine": ">=0.0.4"
+      }
     },
     "split": {
       "version": "1.0.1",
-      "from": "split@>=1.0.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/split/-/split-1.0.1.tgz",
+      "integrity": "sha1-YFvZvjA6pZ+zX5Ip++oN3snqB9k=",
+      "requires": {
+        "through": "2"
+      }
     },
     "sshpk": {
       "version": "1.14.2",
-      "from": "sshpk@>=1.7.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz"
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
+      "requires": {
+        "asn1": "~0.2.3",
+        "assert-plus": "^1.0.0",
+        "bcrypt-pbkdf": "^1.0.0",
+        "dashdash": "^1.12.0",
+        "ecc-jsbn": "~0.1.1",
+        "getpass": "^0.1.1",
+        "jsbn": "~0.1.0",
+        "safer-buffer": "^2.0.2",
+        "tweetnacl": "~0.14.0"
+      }
     },
     "stack-trace": {
       "version": "0.0.10",
-      "from": "stack-trace@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz"
+      "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
+      "integrity": "sha1-VHxws0fo0ytOEI6hoqFZ5f3eGcA="
     },
     "static-eval": {
       "version": "2.0.0",
-      "from": "static-eval@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.0.0.tgz",
+      "integrity": "sha1-DoIfiSaEfe97S1DNpdVcBKmxOGQ=",
+      "requires": {
+        "escodegen": "^1.8.1"
+      }
     },
     "static-module": {
       "version": "2.2.5",
-      "from": "static-module@>=2.1.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz"
+      "resolved": "https://registry.npmjs.org/static-module/-/static-module-2.2.5.tgz",
+      "integrity": "sha1-vUCrzq4z2mt6+4Sg5DKf+IUr+78=",
+      "requires": {
+        "concat-stream": "~1.6.0",
+        "convert-source-map": "^1.5.1",
+        "duplexer2": "~0.1.4",
+        "escodegen": "~1.9.0",
+        "falafel": "^2.1.0",
+        "has": "^1.0.1",
+        "magic-string": "^0.22.4",
+        "merge-source-map": "1.0.4",
+        "object-inspect": "~1.4.0",
+        "quote-stream": "~1.0.2",
+        "readable-stream": "~2.3.3",
+        "shallow-copy": "~0.0.1",
+        "static-eval": "^2.0.0",
+        "through2": "~2.0.3"
+      }
     },
     "statuses": {
       "version": "1.5.0",
-      "from": "statuses@>=1.4.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz"
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow="
     },
     "streamsearch": {
       "version": "0.1.2",
-      "from": "streamsearch@0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
+      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
     },
     "string_decoder": {
       "version": "1.1.1",
-      "from": "string_decoder@>=1.1.1 <1.2.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha1-nPFhG6YmhdcDCunkujQUnDrwP8g=",
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      }
     },
     "stringstream": {
       "version": "0.0.6",
-      "from": "stringstream@>=0.0.5 <0.1.0",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha1-eIAiWw1K0Q4wkn0Weh1vL9OzOnI="
     },
     "tar-stream": {
       "version": "1.6.1",
-      "from": "tar-stream@>=1.5.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz"
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha1-+E7xaWJp1iI8pI9uHu7eP36B85U=",
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.1.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.0",
+        "xtend": "^4.0.0"
+      }
     },
     "throttleit": {
       "version": "1.0.0",
-      "from": "throttleit@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+      "integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
     },
     "through": {
       "version": "2.3.8",
-      "from": "through@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz"
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
     },
     "through2": {
       "version": "2.0.3",
-      "from": "through2@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.3.tgz",
+      "integrity": "sha1-AARWmzfHx0ujnEPzzteNGtlBQL4=",
+      "requires": {
+        "readable-stream": "^2.1.5",
+        "xtend": "~4.0.1"
+      }
     },
     "tmp": {
       "version": "0.0.33",
-      "from": "tmp@>=0.0.0 <0.1.0",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz"
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha1-bTQzWIl2jSGyvNoKonfO07G/rfk=",
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
     },
     "to-buffer": {
       "version": "1.1.1",
-      "from": "to-buffer@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz"
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha1-STvUj2LXxD/N7TE6A9ytsuEhOoA="
     },
     "tough-cookie": {
       "version": "2.3.4",
-      "from": "tough-cookie@>=2.3.3 <2.4.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz"
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+      "integrity": "sha1-7GDO44rGdQY//JelwYlwV47oNlU=",
+      "requires": {
+        "punycode": "^1.4.1"
+      }
     },
     "tunnel-agent": {
       "version": "0.6.0",
-      "from": "tunnel-agent@>=0.6.0 <0.7.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "tweetnacl": {
+      "version": "0.14.5",
+      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
+      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "optional": true
     },
     "type-check": {
       "version": "0.3.2",
-      "from": "type-check@>=0.3.2 <0.4.0",
-      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz"
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
     },
     "type-is": {
       "version": "1.6.16",
-      "from": "type-is@>=1.6.15 <1.7.0",
-      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz"
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.16.tgz",
+      "integrity": "sha1-+JzjQVQcZysl7nrjxz3uOyvlAZQ=",
+      "requires": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.18"
+      }
     },
     "typedarray": {
       "version": "0.0.6",
-      "from": "typedarray@>=0.0.6 <0.0.7",
-      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
     },
     "uglify-js": {
       "version": "2.8.29",
-      "from": "uglify-js@>=2.6.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "optional": true,
+      "requires": {
+        "source-map": "~0.5.1",
+        "uglify-to-browserify": "~1.0.0",
+        "yargs": "~3.10.0"
+      },
       "dependencies": {
         "source-map": {
           "version": "0.5.7",
-          "from": "source-map@>=0.5.1 <0.6.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
           "optional": true
         }
       }
     },
     "uglify-to-browserify": {
       "version": "1.0.2",
-      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "integrity": "sha1-bgkk1r2mta/jSeOabWMoUKD4grc=",
       "optional": true
     },
     "underscore": {
       "version": "1.9.1",
-      "from": "underscore@1.9.1",
-      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz"
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.9.1.tgz",
+      "integrity": "sha512-5/4etnCkd9c8gwgowi5/om/mYO5ajCaOgdzj/oW+0eQV9WxKBDZw5+ycmKmeaTXjInS/W0BzpGLo2xR2aBwZdg=="
     },
     "unpipe": {
       "version": "1.0.0",
-      "from": "unpipe@1.0.0",
-      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha1-sr9O6FFKrmFltIF4KdIbLvSZBOw="
     },
     "useragent": {
       "version": "2.3.0",
-      "from": "useragent@>=2.0.9 <3.0.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
+      "integrity": "sha1-IX+UOtVAyyEoZYqyP8lg9qiMmXI=",
+      "requires": {
+        "lru-cache": "4.1.x",
+        "tmp": "0.0.x"
+      }
     },
     "util-deprecate": {
       "version": "1.0.2",
-      "from": "util-deprecate@>=1.0.1 <1.1.0",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "utils-merge": {
       "version": "1.0.1",
-      "from": "utils-merge@1.0.1",
-      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM="
     },
     "uuid": {
       "version": "3.3.0",
-      "from": "uuid@>=3.1.0 <4.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.0.tgz"
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.0.tgz",
+      "integrity": "sha512-ijO9N2xY/YaOqQ5yz5c4sy2ZjWmA6AR6zASb/gdpeKZ8+948CxwfMW9RrKVk5may6ev8c0/Xguu32e2Llelpqw=="
     },
     "vary": {
       "version": "1.1.2",
-      "from": "vary@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha1-IpnwLG3tMNSllhsLn3RSShj2NPw="
     },
     "verror": {
       "version": "1.10.0",
-      "from": "verror@1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
+      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+      "requires": {
+        "assert-plus": "^1.0.0",
+        "core-util-is": "1.0.2",
+        "extsprintf": "^1.2.0"
+      }
     },
     "vlq": {
       "version": "0.2.3",
-      "from": "vlq@>=0.2.2 <0.3.0",
-      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz"
+      "resolved": "https://registry.npmjs.org/vlq/-/vlq-0.2.3.tgz",
+      "integrity": "sha1-jz5DKM9jsVQMDWfhsneDhviXWyY="
     },
     "which": {
       "version": "1.3.1",
-      "from": "which@>=1.2.10 <2.0.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha1-pFBD1U9YBTFtqNYvn1CRjT2nCwo=",
+      "requires": {
+        "isexe": "^2.0.0"
+      }
     },
     "window-size": {
       "version": "0.1.0",
-      "from": "window-size@0.1.0",
       "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "integrity": "sha1-VDjNLqk7IC76Ohn+iIeu58lPnJ0=",
       "optional": true
     },
     "winston": {
       "version": "2.4.3",
-      "from": "winston@>=2.4.0 <3.0.0",
       "resolved": "https://registry.npmjs.org/winston/-/winston-2.4.3.tgz",
+      "integrity": "sha512-GYKuysPz2pxYAVJD2NPsDLP5Z79SDEzPm9/j4tCjkF/n89iBNGBMJcR+dMUqxgPNgoSs6fVygPi+Vl2oxIpBuw==",
+      "requires": {
+        "async": "~1.0.0",
+        "colors": "1.0.x",
+        "cycle": "1.0.x",
+        "eyes": "0.1.x",
+        "isstream": "0.1.x",
+        "stack-trace": "0.0.x"
+      },
       "dependencies": {
         "async": {
           "version": "1.0.0",
-          "from": "async@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz"
+          "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+          "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
         }
       }
     },
     "wordwrap": {
       "version": "0.0.3",
-      "from": "wordwrap@>=0.0.2 <0.1.0",
-      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz"
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.3.tgz",
+      "integrity": "sha1-o9XabNXAvAAI03I0u68b7WMFkQc="
     },
     "wrappy": {
       "version": "1.0.2",
-      "from": "wrappy@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz"
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "xtend": {
       "version": "4.0.1",
-      "from": "xtend@>=4.0.0 <5.0.0",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
+      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68="
     },
     "yallist": {
       "version": "2.1.2",
-      "from": "yallist@>=2.1.2 <3.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
+      "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI="
     },
     "yargs": {
       "version": "3.10.0",
-      "from": "yargs@>=3.10.0 <3.11.0",
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
-      "optional": true
+      "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
+      "optional": true,
+      "requires": {
+        "camelcase": "^1.0.2",
+        "cliui": "^2.1.0",
+        "decamelize": "^1.0.0",
+        "window-size": "0.1.0"
+      }
     },
     "yauzl": {
       "version": "2.4.1",
-      "from": "yauzl@2.4.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz"
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.4.1.tgz",
+      "integrity": "sha1-lSj0QtqxsihOWLQ3m7GU4i4MQAU=",
+      "requires": {
+        "fd-slicer": "~1.0.1"
+      }
     },
     "zip-stream": {
       "version": "1.2.0",
-      "from": "zip-stream@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz"
+      "resolved": "https://registry.npmjs.org/zip-stream/-/zip-stream-1.2.0.tgz",
+      "integrity": "sha1-qLxF9MG0lpnGuQGYuqyqzbzUugQ=",
+      "requires": {
+        "archiver-utils": "^1.3.0",
+        "compress-commons": "^1.2.0",
+        "lodash": "^4.8.0",
+        "readable-stream": "^2.0.0"
+      }
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.8-BUILD-NUMBER",
+  "version": "6.0.9-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fh-cls-mongoose": "2.1.1",
     "fh-cluster": "0.3.0",
     "fh-component-metrics": "2.7.0",
-    "fh-config": "2.0.0",
+    "fh-config": "1.0.3",
     "fh-forms": "1.16.9",
     "fh-health": "0.3.3",
     "fh-logger": "0.5.2",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21672

# What
fh-mbaas is failing to retrieve the cloud app's connection string.

# Why

The fh-config version was upgraded to 2.0.0 and in the new version the function reload was changed by reloadRawConfig. See [here](https://github.com/feedhenry/fh-config/pull/6)
PS.: It is related to https://github.com/feedhenry/fh-mbaas/pull/130.

# How

Came back the version for the next release

# Verification Steps

* Deploy the fh-mbaas generated by this PR;
* Create a blank project in studio and import the cloud app from this repo: https://github.com/feedhenry/testing-cloud-app;
* Deploy the cloud app and trigger a test by accessing its "/test" route;
* All tests should be green.

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 

