### PR TITLE
Upgrade minor version of fh-messaging-client ( 1.0.4 to 1.0.5)

### DIFF
--- a/licenses/ASYNC-LISTENER_BSD-2-CLAUSE.TXT
+++ b/licenses/ASYNC-LISTENER_BSD-2-CLAUSE.TXT
@@ -1,0 +1,25 @@
+BSD 2-Clause License
+
+Copyright (c) 2013-2017, Forrest L Norvell
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/licenses/ASYNC_MIT.TXT
+++ b/licenses/ASYNC_MIT.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2010 Caolan McMahon
+Copyright (c) 2010-2017 Caolan McMahon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal
@@ -17,4 +17,3 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
-ARE.

--- a/licenses/BCRYPT-PBKDF_BSD-3-CLAUSE.TXT
+++ b/licenses/BCRYPT-PBKDF_BSD-3-CLAUSE.TXT
@@ -1,0 +1,66 @@
+The Blowfish portions are under the following license:
+
+Blowfish block cipher for OpenBSD
+Copyright 1997 Niels Provos <provos@physnet.uni-hamburg.de>
+All rights reserved.
+
+Implementation advice by David Mazieres <dm@lcs.mit.edu>.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+The bcrypt_pbkdf portions are under the following license:
+
+Copyright (c) 2013 Ted Unangst <tedu@openbsd.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+
+Performance improvements (Javascript-specific):
+
+Copyright 2016, Joyent Inc
+Author: Alex Wilson <alex.wilson@joyent.com>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.

--- a/licenses/BUNYAN-LITE_MIT.TXT
+++ b/licenses/BUNYAN-LITE_MIT.TXT
@@ -1,0 +1,24 @@
+# This is the MIT license
+
+Copyright 2016 Trent Mick
+Copyright 2016 Joyent Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+

--- a/licenses/DEEP-EXTEND_MIT.TXT
+++ b/licenses/DEEP-EXTEND_MIT.TXT
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2013 Viacheslav Lotsmanov
+Copyright (c) 2013-2018, Viacheslav Lotsmanov
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the "Software"), to deal in
@@ -18,4 +18,3 @@ FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
 COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-WARE.

--- a/licenses/IS_MIT.TXT
+++ b/licenses/IS_MIT.TXT
@@ -1,0 +1,23 @@
+(The MIT License)
+
+Copyright (c) 2013 Enrico Marino  
+Copyright (c) 2014 Enrico Marino and Jordan Harband
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+'Software'), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED 'AS IS', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/LODASH_MIT.TXT
+++ b/licenses/LODASH_MIT.TXT
@@ -1,6 +1,16 @@
-Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
-Based on Underscore.js 1.5.2, copyright 2009-2013 Jeremy Ashkenas,
+Copyright JS Foundation and other contributors <https://js.foundation/>
+
+Based on Underscore.js, copyright Jeremy Ashkenas,
 DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
+
+This software consists of voluntary contributions made by many
+individuals. For exact contribution history, see the revision history
+available at https://github.com/lodash/lodash
+
+The following license applies to all parts of this software except as
+documented below:
+
+====
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -17,9 +27,6 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.ENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/MV-LITE_MIT.TXT
+++ b/licenses/MV-LITE_MIT.TXT
@@ -1,0 +1,21 @@
+Copyright (c) 2014 Andrew Kelley
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -16,13 +16,6 @@
 <tr>
 <td>N/A</td>
 <td>accepts</td>
-<td>1.3.4</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ACCEPTS_MIT.TXT>ACCEPTS_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>accepts</td>
 <td>1.3.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ACCEPTS_MIT.TXT>ACCEPTS_MIT.TXT</a></td>
@@ -44,14 +37,14 @@
 <tr>
 <td>N/A</td>
 <td>ajv</td>
-<td>5.5.1</td>
+<td>4.11.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=AJV_MIT.TXT>AJV_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>ajv</td>
-<td>4.11.5</td>
+<td>5.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=AJV_MIT.TXT>AJV_MIT.TXT</a></td>
 </tr>
@@ -92,24 +85,10 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>amqp</td>
-<td>0.2.0</td>
+<td>archiver</td>
+<td>1.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>ansi-regex</td>
-<td>2.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ANSI-REGEX_MIT.TXT>ANSI-REGEX_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>ansi-styles</td>
-<td>2.2.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ANSI-STYLES_MIT.TXT>ANSI-STYLES_MIT.TXT</a></td>
+<td><a href=ARCHIVER_MIT.TXT>ARCHIVER_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -117,13 +96,6 @@
 <td>0.4.9</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>archiver</td>
-<td>1.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ARCHIVER_MIT.TXT>ARCHIVER_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -156,14 +128,14 @@
 <tr>
 <td>N/A</td>
 <td>assert-plus</td>
-<td>0.2.0</td>
+<td>1.0.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>assert-plus</td>
-<td>1.0.0</td>
+<td>0.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
@@ -177,14 +149,7 @@
 <tr>
 <td>N/A</td>
 <td>async</td>
-<td>1.5.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>async</td>
-<td>2.1.4</td>
+<td>0.9.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
 </tr>
@@ -205,20 +170,6 @@
 <tr>
 <td>N/A</td>
 <td>async</td>
-<td>0.2.10</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>async</td>
-<td>0.2.7</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>async</td>
 <td>0.2.9</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
@@ -226,9 +177,30 @@
 <tr>
 <td>N/A</td>
 <td>async</td>
-<td>0.9.2</td>
+<td>1.5.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>async</td>
+<td>0.2.10</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>async</td>
+<td>2.1.4</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=ASYNC_MIT.TXT>ASYNC_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>async-listener</td>
+<td>0.6.9</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td><a href=ASYNC-LISTENER_BSD-2-CLAUSE.TXT>ASYNC-LISTENER_BSD-2-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -247,14 +219,14 @@
 <tr>
 <td>N/A</td>
 <td>aws-sign2</td>
-<td>0.6.0</td>
+<td>0.7.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=AWS-SIGN2_APACHE-2.0.TXT>AWS-SIGN2_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>aws-sign2</td>
-<td>0.7.0</td>
+<td>0.6.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=AWS-SIGN2_APACHE-2.0.TXT>AWS-SIGN2_APACHE-2.0.TXT</a></td>
 </tr>
@@ -268,7 +240,7 @@
 <tr>
 <td>N/A</td>
 <td>aws4</td>
-<td>1.5.0</td>
+<td>1.8.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=AWS4_MIT.TXT>AWS4_MIT.TXT</a></td>
 </tr>
@@ -289,14 +261,14 @@
 <tr>
 <td>N/A</td>
 <td>balanced-match</td>
-<td>1.0.0</td>
+<td>0.4.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=BALANCED-MATCH_MIT.TXT>BALANCED-MATCH_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>balanced-match</td>
-<td>0.4.2</td>
+<td>1.0.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=BALANCED-MATCH_MIT.TXT>BALANCED-MATCH_MIT.TXT</a></td>
 </tr>
@@ -306,6 +278,13 @@
 <td>0.1.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>bcrypt-pbkdf</td>
+<td>1.0.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=BCRYPT-PBKDF_BSD-3-CLAUSE.TXT>BCRYPT-PBKDF_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -352,13 +331,6 @@
 <tr>
 <td>N/A</td>
 <td>boom</td>
-<td>5.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=BOOM_BSD-3-CLAUSE.TXT>BOOM_BSD-3-CLAUSE.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>boom</td>
 <td>2.10.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=BOOM_BSD-3-CLAUSE.TXT>BOOM_BSD-3-CLAUSE.TXT</a></td>
@@ -372,10 +344,10 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>brace-expansion</td>
-<td>1.1.6</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
+<td>boom</td>
+<td>5.2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=BOOM_BSD-3-CLAUSE.TXT>BOOM_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -383,6 +355,13 @@
 <td>1.1.11</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=BRACE-EXPANSION_MIT.TXT>BRACE-EXPANSION_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>brace-expansion</td>
+<td>1.1.6</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -401,6 +380,13 @@
 <tr>
 <td>N/A</td>
 <td>bson</td>
+<td>1.0.9</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=BSON_APACHE-2.0.TXT>BSON_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>bson</td>
 <td>0.4.23</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=BSON_APACHE-2.0.TXT>BSON_APACHE-2.0.TXT</a></td>
@@ -411,13 +397,6 @@
 <td>0.2.2</td>
 <td>UNKNOWN, UNKNOWN</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>bson</td>
-<td>1.0.9</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=BSON_APACHE-2.0.TXT>BSON_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -485,7 +464,7 @@
 <tr>
 <td>N/A</td>
 <td>bunyan</td>
-<td>1.8.4</td>
+<td>1.8.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=BUNYAN_MIT.TXT>BUNYAN_MIT.TXT</a></td>
 </tr>
@@ -506,9 +485,16 @@
 <tr>
 <td>N/A</td>
 <td>bunyan</td>
-<td>1.8.5</td>
+<td>1.8.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=BUNYAN_MIT.TXT>BUNYAN_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>bunyan-lite</td>
+<td>1.0.1</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=BUNYAN-LITE_MIT.TXT>BUNYAN-LITE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -527,14 +513,14 @@
 <tr>
 <td>N/A</td>
 <td>camelcase</td>
-<td>2.1.1</td>
+<td>1.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=CAMELCASE_MIT.TXT>CAMELCASE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>camelcase</td>
-<td>1.2.1</td>
+<td>2.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=CAMELCASE_MIT.TXT>CAMELCASE_MIT.TXT</a></td>
 </tr>
@@ -554,24 +540,10 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>caseless</td>
-<td>0.11.0</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=CASELESS_APACHE-2.0.TXT>CASELESS_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>center-align</td>
 <td>0.1.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=CENTER-ALIGN_MIT.TXT>CENTER-ALIGN_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>chalk</td>
-<td>1.1.3</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=CHALK_MIT.TXT>CHALK_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -617,13 +589,6 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>commander</td>
-<td>2.9.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=COMMANDER_MIT.TXT>COMMANDER_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>compress-commons</td>
 <td>1.2.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
@@ -656,6 +621,13 @@
 <td>1.0.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=CONTENT-TYPE_MIT.TXT>CONTENT-TYPE_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>continuation-local-storage</td>
+<td>3.2.1</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td><a href=CONTINUATION-LOCAL-STORAGE_BSD-2-CLAUSE.TXT>CONTINUATION-LOCAL-STORAGE_BSD-2-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -730,14 +702,14 @@
 <tr>
 <td>N/A</td>
 <td>cryptiles</td>
-<td>2.0.5</td>
+<td>3.1.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=CRYPTILES_BSD-3-CLAUSE.TXT>CRYPTILES_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>cryptiles</td>
-<td>3.1.2</td>
+<td>2.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=CRYPTILES_BSD-3-CLAUSE.TXT>CRYPTILES_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -835,21 +807,14 @@
 <tr>
 <td>N/A</td>
 <td>depd</td>
-<td>1.1.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=DEPD_MIT.TXT>DEPD_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>depd</td>
-<td>1.1.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=DEPD_MIT.TXT>DEPD_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>depd</td>
 <td>1.1.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=DEPD_MIT.TXT>DEPD_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>depd</td>
+<td>1.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=DEPD_MIT.TXT>DEPD_MIT.TXT</a></td>
 </tr>
@@ -877,14 +842,14 @@
 <tr>
 <td>N/A</td>
 <td>dtrace-provider</td>
-<td>0.7.1</td>
+<td>0.8.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=DTRACE-PROVIDER_BSD-2-CLAUSE.TXT>DTRACE-PROVIDER_BSD-2-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>dtrace-provider</td>
-<td>0.8.5</td>
+<td>0.7.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=DTRACE-PROVIDER_BSD-2-CLAUSE.TXT>DTRACE-PROVIDER_BSD-2-CLAUSE.TXT</a></td>
 </tr>
@@ -912,6 +877,13 @@
 <tr>
 <td>N/A</td>
 <td>ecc-jsbn</td>
+<td>0.1.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=ECC-JSBN_MIT.TXT>ECC-JSBN_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>ecc-jsbn</td>
 <td>0.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ECC-JSBN_MIT.TXT>ECC-JSBN_MIT.TXT</a></td>
@@ -926,16 +898,16 @@
 <tr>
 <td>N/A</td>
 <td>emitter-listener</td>
-<td>1.0.1</td>
+<td>1.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
-<td>encodeurl</td>
+<td>emitter-listener</td>
 <td>1.0.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ENCODEURL_MIT.TXT>ENCODEURL_MIT.TXT</a></td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -961,13 +933,6 @@
 <tr>
 <td>N/A</td>
 <td>es6-promise</td>
-<td>3.2.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ES6-PROMISE_MIT.TXT>ES6-PROMISE_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>es6-promise</td>
 <td>3.0.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ES6-PROMISE_MIT.TXT>ES6-PROMISE_MIT.TXT</a></td>
@@ -975,7 +940,14 @@
 <tr>
 <td>N/A</td>
 <td>es6-promise</td>
-<td>4.2.4</td>
+<td>3.2.1</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=ES6-PROMISE_MIT.TXT>ES6-PROMISE_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>es6-promise</td>
+<td>4.2.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ES6-PROMISE_MIT.TXT>ES6-PROMISE_MIT.TXT</a></td>
 </tr>
@@ -985,13 +957,6 @@
 <td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ESCAPE-HTML_MIT.TXT>ESCAPE-HTML_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>escape-string-regexp</td>
-<td>1.0.5</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=ESCAPE-STRING-REGEXP_MIT.TXT>ESCAPE-STRING-REGEXP_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1067,6 +1032,13 @@
 <td>N/A</td>
 <td>extend</td>
 <td>3.0.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=EXTEND_MIT.TXT>EXTEND_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>extend</td>
+<td>3.0.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=EXTEND_MIT.TXT>EXTEND_MIT.TXT</a></td>
 </tr>
@@ -1150,13 +1122,6 @@
 <tr>
 <td>N/A</td>
 <td>fh-amqp-js</td>
-<td>0.7.1</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=FH-AMQP-JS_APACHE-2.0.TXT>FH-AMQP-JS_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>fh-amqp-js</td>
 <td>0.7.5</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-AMQP-JS_APACHE-2.0.TXT>FH-AMQP-JS_APACHE-2.0.TXT</a></td>
@@ -1185,14 +1150,14 @@
 <tr>
 <td>N/A</td>
 <td>fh-config</td>
-<td>2.0.0</td>
+<td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-CONFIG_APACHE-2.0.TXT>FH-CONFIG_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>fh-forms</td>
-<td>1.16.9</td>
+<td>1.16.10</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-FORMS_APACHE-2.0.TXT>FH-FORMS_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1213,21 +1178,28 @@
 <tr>
 <td>N/A</td>
 <td>fh-logger</td>
-<td>0.5.0</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=FH-LOGGER_APACHE-2.0.TXT>FH-LOGGER_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>fh-logger</td>
 <td>0.5.2</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-LOGGER_APACHE-2.0.TXT>FH-LOGGER_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
+<td>fh-logger</td>
+<td>1.0.0</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=FH-LOGGER_APACHE-2.0.TXT>FH-LOGGER_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>fh-logger</td>
+<td>0.5.0</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=FH-LOGGER_APACHE-2.0.TXT>FH-LOGGER_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>fh-mbaas</td>
-<td>6.0.7-BUILD-NUMBER</td>
+<td>6.0.12-BUILD-NUMBER</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS_APACHE-2.0.TXT>FH-MBAAS_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1241,14 +1213,14 @@
 <tr>
 <td>N/A</td>
 <td>fh-mbaas-middleware</td>
-<td>2.3.2</td>
+<td>2.3.5</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS-MIDDLEWARE_APACHE-2.0.TXT>FH-MBAAS-MIDDLEWARE_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>fh-messaging-client</td>
-<td>1.0.4</td>
+<td>1.0.5</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MESSAGING-CLIENT_APACHE-2.0.TXT>FH-MESSAGING-CLIENT_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1311,14 +1283,14 @@
 <tr>
 <td>N/A</td>
 <td>form-data</td>
-<td>2.1.2</td>
+<td>2.3.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=FORM-DATA_MIT.TXT>FORM-DATA_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>form-data</td>
-<td>2.3.1</td>
+<td>2.1.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=FORM-DATA_MIT.TXT>FORM-DATA_MIT.TXT</a></td>
 </tr>
@@ -1373,20 +1345,6 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>generate-function</td>
-<td>2.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>generate-object-property</td>
-<td>1.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=GENERATE-OBJECT-PROPERTY_MIT.TXT>GENERATE-OBJECT-PROPERTY_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>get-stdin</td>
 <td>4.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
@@ -1395,14 +1353,14 @@
 <tr>
 <td>N/A</td>
 <td>getpass</td>
-<td>0.1.6</td>
+<td>0.1.7</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=GETPASS_MIT.TXT>GETPASS_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>getpass</td>
-<td>0.1.7</td>
+<td>0.1.6</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=GETPASS_MIT.TXT>GETPASS_MIT.TXT</a></td>
 </tr>
@@ -1423,9 +1381,9 @@
 <tr>
 <td>N/A</td>
 <td>graceful-fs</td>
-<td>2.0.3</td>
-<td>UNKNOWN</td>
-<td><a href=GRACEFUL-FS_BSD*.TXT>GRACEFUL-FS_BSD*.TXT</a></td>
+<td>4.1.11</td>
+<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
+<td><a href=GRACEFUL-FS_ISC.TXT>GRACEFUL-FS_ISC.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1437,16 +1395,9 @@
 <tr>
 <td>N/A</td>
 <td>graceful-fs</td>
-<td>4.1.11</td>
-<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
-<td><a href=GRACEFUL-FS_ISC.TXT>GRACEFUL-FS_ISC.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>graceful-readlink</td>
-<td>1.0.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=GRACEFUL-READLINK_MIT.TXT>GRACEFUL-READLINK_MIT.TXT</a></td>
+<td>2.0.3</td>
+<td>UNKNOWN</td>
+<td><a href=GRACEFUL-FS_BSD*.TXT>GRACEFUL-FS_BSD*.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1465,21 +1416,21 @@
 <tr>
 <td>N/A</td>
 <td>har-schema</td>
-<td>2.0.0</td>
-<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
-<td><a href=HAR-SCHEMA_ISC.TXT>HAR-SCHEMA_ISC.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>har-schema</td>
 <td>1.0.5</td>
 <td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
 <td><a href=HAR-SCHEMA_ISC.TXT>HAR-SCHEMA_ISC.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
+<td>har-schema</td>
+<td>2.0.0</td>
+<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
+<td><a href=HAR-SCHEMA_ISC.TXT>HAR-SCHEMA_ISC.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>har-validator</td>
-<td>2.0.6</td>
+<td>5.1.0</td>
 <td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
 <td><a href=HAR-VALIDATOR_ISC.TXT>HAR-VALIDATOR_ISC.TXT</a></td>
 </tr>
@@ -1506,24 +1457,10 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>has-ansi</td>
-<td>2.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=HAS-ANSI_MIT.TXT>HAS-ANSI_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>hasha</td>
 <td>2.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=HASHA_MIT.TXT>HASHA_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>hawk</td>
-<td>6.0.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=HAWK_BSD-3-CLAUSE.TXT>HAWK_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1534,15 +1471,22 @@
 </tr>
 <tr>
 <td>N/A</td>
+<td>hawk</td>
+<td>6.0.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=HAWK_BSD-3-CLAUSE.TXT>HAWK_BSD-3-CLAUSE.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>hoek</td>
-<td>4.2.0</td>
+<td>4.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=HOEK_BSD-3-CLAUSE.TXT>HOEK_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>hoek</td>
-<td>4.2.1</td>
+<td>4.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=HOEK_BSD-3-CLAUSE.TXT>HOEK_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -1584,28 +1528,28 @@
 <tr>
 <td>N/A</td>
 <td>http-errors</td>
-<td>1.6.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=HTTP-ERRORS_MIT.TXT>HTTP-ERRORS_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>http-errors</td>
 <td>1.6.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=HTTP-ERRORS_MIT.TXT>HTTP-ERRORS_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
+<td>http-errors</td>
+<td>1.6.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=HTTP-ERRORS_MIT.TXT>HTTP-ERRORS_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>http-signature</td>
-<td>1.1.1</td>
+<td>1.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=HTTP-SIGNATURE_MIT.TXT>HTTP-SIGNATURE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>http-signature</td>
-<td>1.2.0</td>
+<td>1.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=HTTP-SIGNATURE_MIT.TXT>HTTP-SIGNATURE_MIT.TXT</a></td>
 </tr>
@@ -1640,14 +1584,14 @@
 <tr>
 <td>N/A</td>
 <td>iconv-lite</td>
-<td>0.4.19</td>
+<td>0.2.11</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ICONV-LITE_MIT.TXT>ICONV-LITE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>iconv-lite</td>
-<td>0.2.11</td>
+<td>0.4.19</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ICONV-LITE_MIT.TXT>ICONV-LITE_MIT.TXT</a></td>
 </tr>
@@ -1702,10 +1646,10 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>ipaddr.js</td>
-<td>1.5.2</td>
+<td>is</td>
+<td>3.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=IPADDR.JS_MIT.TXT>IPADDR.JS_MIT.TXT</a></td>
+<td><a href=IS_MIT.TXT>IS_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1734,20 +1678,6 @@
 <td>1.0.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=IS-FINITE_MIT.TXT>IS-FINITE_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>is-my-json-valid</td>
-<td>2.15.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=IS-MY-JSON-VALID_MIT.TXT>IS-MY-JSON-VALID_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>is-property</td>
-<td>1.0.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=IS-PROPERTY_MIT.TXT>IS-PROPERTY_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1856,13 +1786,6 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>jsonpointer</td>
-<td>4.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=JSONPOINTER_MIT.TXT>JSONPOINTER_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>jsprim</td>
 <td>1.4.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
@@ -1962,7 +1885,7 @@
 <tr>
 <td>N/A</td>
 <td>lodash</td>
-<td>2.2.1</td>
+<td>4.17.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
 </tr>
@@ -1976,16 +1899,16 @@
 <tr>
 <td>N/A</td>
 <td>lodash</td>
-<td>4.17.4</td>
+<td>3.10.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>lodash</td>
-<td>1.3.1</td>
+<td>2.4.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
+<td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1997,21 +1920,7 @@
 <tr>
 <td>N/A</td>
 <td>lodash</td>
-<td>3.10.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>lodash</td>
-<td>2.4.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>lodash</td>
-<td>2.4.2</td>
+<td>2.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=LODASH_MIT.TXT>LODASH_MIT.TXT</a></td>
 </tr>
@@ -2137,7 +2046,21 @@
 <tr>
 <td>N/A</td>
 <td>mime-db</td>
-<td>1.24.0</td>
+<td>1.26.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
+<td>1.33.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
+<td>1.36.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
 </tr>
@@ -2157,22 +2080,15 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>mime-db</td>
-<td>1.26.0</td>
+<td>mime-types</td>
+<td>2.0.14</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-db</td>
-<td>1.33.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mime-types</td>
-<td>2.1.18</td>
+<td>2.1.14</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
@@ -2186,21 +2102,14 @@
 <tr>
 <td>N/A</td>
 <td>mime-types</td>
-<td>2.0.14</td>
+<td>2.1.18</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mime-types</td>
-<td>2.1.12</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-types</td>
-<td>2.1.14</td>
+<td>2.1.20</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
@@ -2234,22 +2143,15 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>minimist</td>
-<td>0.0.10</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MINIMIST_MIT.TXT>MINIMIST_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>mkdirp</td>
-<td>0.5.1</td>
+<td>0.3.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MKDIRP_MIT.TXT>MKDIRP_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mkdirp</td>
-<td>0.3.5</td>
+<td>0.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MKDIRP_MIT.TXT>MKDIRP_MIT.TXT</a></td>
 </tr>
@@ -2354,14 +2256,14 @@
 <tr>
 <td>N/A</td>
 <td>mongodb-core</td>
-<td>1.3.10</td>
+<td>1.3.18</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mongodb-core</td>
-<td>1.3.18</td>
+<td>1.3.10</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
 </tr>
@@ -2382,15 +2284,15 @@
 <tr>
 <td>N/A</td>
 <td>mongoose</td>
-<td>4.11.14</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td>3.6.20</td>
+<td>UNKNOWN</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mongoose</td>
-<td>3.6.20</td>
-<td>UNKNOWN</td>
+<td>4.11.14</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
@@ -2424,7 +2326,7 @@
 <tr>
 <td>N/A</td>
 <td>mongoose-validator</td>
-<td>1.2.5</td>
+<td>1.3.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MONGOOSE-VALIDATOR_MIT.TXT>MONGOOSE-VALIDATOR_MIT.TXT</a></td>
 </tr>
@@ -2507,15 +2409,15 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>nan</td>
-<td>2.4.0</td>
+<td>mv-lite</td>
+<td>1.0.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
+<td><a href=MV-LITE_MIT.TXT>MV-LITE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>nan</td>
-<td>2.7.0</td>
+<td>2.4.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
 </tr>
@@ -2530,6 +2432,13 @@
 <td>N/A</td>
 <td>nan</td>
 <td>2.3.5</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>nan</td>
+<td>2.7.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=NAN_MIT.TXT>NAN_MIT.TXT</a></td>
 </tr>
@@ -2648,6 +2557,13 @@
 <tr>
 <td>N/A</td>
 <td>oauth-sign</td>
+<td>0.9.0</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=OAUTH-SIGN_APACHE-2.0.TXT>OAUTH-SIGN_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>oauth-sign</td>
 <td>0.8.2</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=OAUTH-SIGN_APACHE-2.0.TXT>OAUTH-SIGN_APACHE-2.0.TXT</a></td>
@@ -2691,13 +2607,6 @@
 <td>N/A</td>
 <td>optimist</td>
 <td>0.6.1</td>
-<td>UNKNOWN</td>
-<td><a href=OPTIMIST_MIT*.TXT>OPTIMIST_MIT*.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>optimist</td>
-<td>0.3.7</td>
 <td>UNKNOWN</td>
 <td><a href=OPTIMIST_MIT*.TXT>OPTIMIST_MIT*.TXT</a></td>
 </tr>
@@ -2871,17 +2780,17 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>proxy-addr</td>
-<td>2.0.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=PROXY-ADDR_MIT.TXT>PROXY-ADDR_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>pseudomap</td>
 <td>1.0.2</td>
 <td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
 <td><a href=PSEUDOMAP_ISC.TXT>PSEUDOMAP_ISC.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>psl</td>
+<td>1.1.29</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -2893,13 +2802,6 @@
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>1.2.2</td>
-<td>UNKNOWN</td>
-<td><a href=QS_BSD.TXT>QS_BSD.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>qs</td>
 <td>6.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
@@ -2907,14 +2809,21 @@
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>6.3.0</td>
+<td>6.4.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>6.4.0</td>
+<td>1.2.2</td>
+<td>UNKNOWN</td>
+<td><a href=QS_BSD.TXT>QS_BSD.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>qs</td>
+<td>6.5.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -2942,13 +2851,6 @@
 <tr>
 <td>N/A</td>
 <td>rc</td>
-<td>0.1.1</td>
-<td>UNKNOWN</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>rc</td>
 <td>0.4.0</td>
 <td>UNKNOWN</td>
 <td><a href=RC_BSD%2CMIT%2CAPACHE2.TXT>RC_BSD,MIT,APACHE2.TXT</a></td>
@@ -2957,14 +2859,14 @@
 <td>N/A</td>
 <td>rc</td>
 <td>1.2.8</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=RC_(BSD-2-CLAUSE%20OR%20MIT%20OR%20APACHE-2.0).TXT>RC_(BSD-2-CLAUSE OR MIT OR APACHE-2.0).TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>rc</td>
 <td>1.2.8</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=RC_(BSD-2-CLAUSE%20OR%20MIT%20OR%20APACHE-2.0).TXT>RC_(BSD-2-CLAUSE OR MIT OR APACHE-2.0).TXT</a></td>
 </tr>
 <tr>
@@ -3032,13 +2934,6 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>redis</td>
-<td>0.8.2</td>
-<td>UNKNOWN</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>regexp-clone</td>
 <td>0.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
@@ -3068,7 +2963,7 @@
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.78.0</td>
+<td>2.83.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
@@ -3089,7 +2984,7 @@
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.83.0</td>
+<td>2.88.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
@@ -3131,6 +3026,13 @@
 <tr>
 <td>N/A</td>
 <td>rimraf</td>
+<td>2.4.5</td>
+<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
+<td><a href=RIMRAF_ISC.TXT>RIMRAF_ISC.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>rimraf</td>
 <td>2.2.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=RIMRAF_MIT.TXT>RIMRAF_MIT.TXT</a></td>
@@ -3144,22 +3046,8 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>rimraf</td>
-<td>2.4.5</td>
-<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
-<td><a href=RIMRAF_ISC.TXT>RIMRAF_ISC.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>safe-buffer</td>
 <td>5.1.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=SAFE-BUFFER_MIT.TXT>SAFE-BUFFER_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>safe-buffer</td>
-<td>5.1.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SAFE-BUFFER_MIT.TXT>SAFE-BUFFER_MIT.TXT</a></td>
 </tr>
@@ -3172,15 +3060,22 @@
 </tr>
 <tr>
 <td>N/A</td>
+<td>safe-buffer</td>
+<td>5.1.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=SAFE-BUFFER_MIT.TXT>SAFE-BUFFER_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>safe-json-stringify</td>
-<td>1.0.4</td>
+<td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>safe-json-stringify</td>
-<td>1.0.3</td>
+<td>1.0.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
@@ -3216,13 +3111,6 @@
 <td>N/A</td>
 <td>semver</td>
 <td>5.3.0</td>
-<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
-<td><a href=SEMVER_ISC.TXT>SEMVER_ISC.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>semver</td>
-<td>5.4.1</td>
 <td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
 <td><a href=SEMVER_ISC.TXT>SEMVER_ISC.TXT</a></td>
 </tr>
@@ -3292,15 +3180,15 @@
 <tr>
 <td>N/A</td>
 <td>shimmer</td>
-<td>1.0.0</td>
-<td>UNKNOWN</td>
+<td>1.2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>shimmer</td>
-<td>1.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td>1.0.0</td>
+<td>UNKNOWN</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
@@ -3313,13 +3201,6 @@
 <tr>
 <td>N/A</td>
 <td>sliced</td>
-<td>0.0.4</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>sliced</td>
 <td>0.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
@@ -3328,6 +3209,13 @@
 <td>N/A</td>
 <td>sliced</td>
 <td>1.0.1</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>sliced</td>
+<td>0.0.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
 </tr>
@@ -3355,16 +3243,16 @@
 <tr>
 <td>N/A</td>
 <td>sntp</td>
-<td>2.1.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=SNTP_BSD-3-CLAUSE.TXT>SNTP_BSD-3-CLAUSE.TXT</a></td>
+<td>1.0.9</td>
+<td>UNKNOWN</td>
+<td><a href=SNTP_BSD.TXT>SNTP_BSD.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>sntp</td>
-<td>1.0.9</td>
-<td>UNKNOWN</td>
-<td><a href=SNTP_BSD.TXT>SNTP_BSD.TXT</a></td>
+<td>2.1.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=SNTP_BSD-3-CLAUSE.TXT>SNTP_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3384,6 +3272,13 @@
 <td>N/A</td>
 <td>source-map</td>
 <td>0.5.7</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=SOURCE-MAP_BSD-3-CLAUSE.TXT>SOURCE-MAP_BSD-3-CLAUSE.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>source-map</td>
+<td>0.6.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=SOURCE-MAP_BSD-3-CLAUSE.TXT>SOURCE-MAP_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -3502,14 +3397,14 @@
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>0.10.31</td>
+<td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>1.0.3</td>
+<td>0.10.31</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>
@@ -3523,23 +3418,16 @@
 <tr>
 <td>N/A</td>
 <td>stringstream</td>
-<td>0.0.6</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=STRINGSTREAM_MIT.TXT>STRINGSTREAM_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>stringstream</td>
 <td>0.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRINGSTREAM_MIT.TXT>STRINGSTREAM_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
-<td>strip-ansi</td>
-<td>3.0.1</td>
+<td>stringstream</td>
+<td>0.0.6</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=STRIP-ANSI_MIT.TXT>STRIP-ANSI_MIT.TXT</a></td>
+<td><a href=STRINGSTREAM_MIT.TXT>STRINGSTREAM_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3568,13 +3456,6 @@
 <td>2.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRIP-JSON-COMMENTS_MIT.TXT>STRIP-JSON-COMMENTS_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>supports-color</td>
-<td>2.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=SUPPORTS-COLOR_MIT.TXT>SUPPORTS-COLOR_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3621,6 +3502,13 @@
 <tr>
 <td>N/A</td>
 <td>tough-cookie</td>
+<td>2.3.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>tough-cookie</td>
 <td>2.3.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
@@ -3635,7 +3523,7 @@
 <tr>
 <td>N/A</td>
 <td>tough-cookie</td>
-<td>2.3.2</td>
+<td>2.4.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -3650,13 +3538,6 @@
 <td>N/A</td>
 <td>tunnel-agent</td>
 <td>0.6.0</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=TUNNEL-AGENT_APACHE-2.0.TXT>TUNNEL-AGENT_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>tunnel-agent</td>
-<td>0.4.3</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=TUNNEL-AGENT_APACHE-2.0.TXT>TUNNEL-AGENT_APACHE-2.0.TXT</a></td>
 </tr>
@@ -3678,13 +3559,6 @@
 <td>N/A</td>
 <td>type-is</td>
 <td>1.5.7</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=TYPE-IS_MIT.TXT>TYPE-IS_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>type-is</td>
-<td>1.6.15</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=TYPE-IS_MIT.TXT>TYPE-IS_MIT.TXT</a></td>
 </tr>
@@ -3719,13 +3593,6 @@
 <tr>
 <td>N/A</td>
 <td>underscore</td>
-<td>1.7.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>underscore</td>
 <td>1.8.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
@@ -3733,14 +3600,21 @@
 <tr>
 <td>N/A</td>
 <td>underscore</td>
-<td>1.9.1</td>
+<td>1.8.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>underscore</td>
-<td>1.8.0</td>
+<td>1.7.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>underscore</td>
+<td>1.9.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
 </tr>
@@ -3782,13 +3656,6 @@
 <tr>
 <td>N/A</td>
 <td>uuid</td>
-<td>3.3.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>uuid</td>
 <td>3.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
@@ -3796,7 +3663,21 @@
 <tr>
 <td>N/A</td>
 <td>uuid</td>
+<td>3.3.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>uuid</td>
 <td>3.1.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>uuid</td>
+<td>3.3.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
 </tr>
@@ -3810,7 +3691,7 @@
 <tr>
 <td>N/A</td>
 <td>validator</td>
-<td>4.9.0</td>
+<td>7.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=VALIDATOR_MIT.TXT>VALIDATOR_MIT.TXT</a></td>
 </tr>
@@ -3866,7 +3747,7 @@
 <tr>
 <td>N/A</td>
 <td>winston</td>
-<td>2.4.3</td>
+<td>2.4.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=WINSTON_MIT.TXT>WINSTON_MIT.TXT</a></td>
 </tr>

--- a/licenses/licenses.xml
+++ b/licenses/licenses.xml
@@ -1,19 +1,9 @@
 <?xml version='1.0'?>
 <licenseSummary>
     <project>fh-mbaas</project>
-    <version>6.0.7-BUILD-NUMBER</version>
+    <version>6.0.12-BUILD-NUMBER</version>
     <license>Apache-2.0</license>
     <dependencies>
-        <dependency>
-            <packageName>accepts</packageName>
-            <version>1.3.4</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
         <dependency>
             <packageName>accepts</packageName>
             <version>1.3.5</version>
@@ -100,37 +90,7 @@
         </dependency>
         <dependency>
             <packageName>amqp</packageName>
-            <version>0.2.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>amqp</packageName>
             <version>0.2.6</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>ansi-regex</packageName>
-            <version>2.0.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>ansi-styles</packageName>
-            <version>2.2.1</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -229,18 +189,18 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>async</packageName>
-            <version>0.2.10</version>
+            <packageName>async-listener</packageName>
+            <version>0.6.9</version>
             <licenses>
                 <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
+                    <name>BSD 2-clause "Simplified" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-2-Clause</url>
                 </license>
             </licenses>
         </dependency>
         <dependency>
             <packageName>async</packageName>
-            <version>0.2.7</version>
+            <version>0.2.10</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -350,16 +310,6 @@
         </dependency>
         <dependency>
             <packageName>aws4</packageName>
-            <version>1.5.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>aws4</packageName>
             <version>1.6.0</version>
             <licenses>
                 <license>
@@ -371,6 +321,16 @@
         <dependency>
             <packageName>aws4</packageName>
             <version>1.7.0</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>aws4</packageName>
+            <version>1.8.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -421,6 +381,16 @@
         <dependency>
             <packageName>bcrypt-pbkdf</packageName>
             <version>1.0.1</version>
+            <licenses>
+                <license>
+                    <name>BSD 3-clause "New" or "Revised" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>bcrypt-pbkdf</packageName>
+            <version>1.0.2</version>
             <licenses>
                 <license>
                     <name>BSD 3-clause "New" or "Revised" License</name>
@@ -669,6 +639,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>bunyan-lite</packageName>
+            <version>1.0.1</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>bunyan</packageName>
             <version>1.8.1</version>
             <licenses>
@@ -760,16 +740,6 @@
         </dependency>
         <dependency>
             <packageName>caseless</packageName>
-            <version>0.11.0</version>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>caseless</packageName>
             <version>0.12.0</version>
             <licenses>
                 <license>
@@ -781,16 +751,6 @@
         <dependency>
             <packageName>center-align</packageName>
             <version>0.1.3</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>chalk</packageName>
-            <version>1.1.3</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -859,16 +819,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>commander</packageName>
-            <version>2.9.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>compress-commons</packageName>
             <version>1.2.2</version>
             <licenses>
@@ -921,6 +871,16 @@
         <dependency>
             <packageName>continuation-local-storage</packageName>
             <version>3.1.7</version>
+            <licenses>
+                <license>
+                    <name>BSD 2-clause "Simplified" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-2-Clause</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>continuation-local-storage</packageName>
+            <version>3.2.1</version>
             <licenses>
                 <license>
                     <name>BSD 2-clause "Simplified" License</name>
@@ -1170,16 +1130,6 @@
         </dependency>
         <dependency>
             <packageName>depd</packageName>
-            <version>1.1.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>depd</packageName>
             <version>1.1.1</version>
             <licenses>
                 <license>
@@ -1289,6 +1239,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>ecc-jsbn</packageName>
+            <version>0.1.2</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>ee-first</packageName>
             <version>1.1.1</version>
             <licenses>
@@ -1309,12 +1269,12 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>encodeurl</packageName>
-            <version>1.0.1</version>
+            <packageName>emitter-listener</packageName>
+            <version>1.1.1</version>
             <licenses>
                 <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
+                    <name>BSD 2-clause "Simplified" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-2-Clause</url>
                 </license>
             </licenses>
         </dependency>
@@ -1370,7 +1330,7 @@
         </dependency>
         <dependency>
             <packageName>es6-promise</packageName>
-            <version>4.2.4</version>
+            <version>4.2.5</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -1381,16 +1341,6 @@
         <dependency>
             <packageName>escape-html</packageName>
             <version>1.0.3</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>escape-string-regexp</packageName>
-            <version>1.0.5</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -1501,6 +1451,16 @@
         <dependency>
             <packageName>extend</packageName>
             <version>3.0.1</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>extend</packageName>
+            <version>3.0.2</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -1620,16 +1580,6 @@
         </dependency>
         <dependency>
             <packageName>fh-amqp-js</packageName>
-            <version>0.7.1</version>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>fh-amqp-js</packageName>
             <version>0.7.5</version>
             <licenses>
                 <license>
@@ -1670,7 +1620,7 @@
         </dependency>
         <dependency>
             <packageName>fh-config</packageName>
-            <version>2.0.0</version>
+            <version>1.0.3</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1680,7 +1630,7 @@
         </dependency>
         <dependency>
             <packageName>fh-forms</packageName>
-            <version>1.16.9</version>
+            <version>1.16.10</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1729,6 +1679,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>fh-logger</packageName>
+            <version>1.0.0</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>fh-mbaas-client</packageName>
             <version>1.1.1</version>
             <licenses>
@@ -1740,7 +1700,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas-middleware</packageName>
-            <version>2.3.2</version>
+            <version>2.3.5</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1750,7 +1710,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas</packageName>
-            <version>6.0.7-BUILD-NUMBER</version>
+            <version>6.0.12-BUILD-NUMBER</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1760,7 +1720,7 @@
         </dependency>
         <dependency>
             <packageName>fh-messaging-client</packageName>
-            <version>1.0.4</version>
+            <version>1.0.5</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1939,26 +1899,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>generate-function</packageName>
-            <version>2.0.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>generate-object-property</packageName>
-            <version>1.2.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>get-stdin</packageName>
             <version>4.0.1</version>
             <licenses>
@@ -2039,16 +1979,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>graceful-readlink</packageName>
-            <version>1.0.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>gridfs-stream</packageName>
             <version>0.4.0</version>
             <licenses>
@@ -2090,16 +2020,6 @@
         </dependency>
         <dependency>
             <packageName>har-validator</packageName>
-            <version>2.0.6</version>
-            <licenses>
-                <license>
-                    <name>ISC License</name>
-                    <url>http://www.isc.org/software/license</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>har-validator</packageName>
             <version>4.2.1</version>
             <licenses>
                 <license>
@@ -2119,12 +2039,12 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>has-ansi</packageName>
-            <version>2.0.0</version>
+            <packageName>har-validator</packageName>
+            <version>5.1.0</version>
             <licenses>
                 <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
+                    <name>ISC License</name>
+                    <url>http://www.isc.org/software/license</url>
                 </license>
             </licenses>
         </dependency>
@@ -2400,16 +2320,6 @@
         </dependency>
         <dependency>
             <packageName>ipaddr.js</packageName>
-            <version>1.5.2</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>ipaddr.js</packageName>
             <version>1.6.0</version>
             <licenses>
                 <license>
@@ -2459,26 +2369,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>is-my-json-valid</packageName>
-            <version>2.15.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>is-property</packageName>
-            <version>1.0.2</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>is-stream</packageName>
             <version>1.1.0</version>
             <licenses>
@@ -2501,6 +2391,16 @@
         <dependency>
             <packageName>is-utf8</packageName>
             <version>0.2.1</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>is</packageName>
+            <version>3.2.1</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -2625,16 +2525,6 @@
                 <license>
                     <name>UNKNOWN</name>
                     <url>UNKNOWN</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>jsonpointer</packageName>
-            <version>4.0.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
                 </license>
             </licenses>
         </dependency>
@@ -2830,16 +2720,6 @@
         </dependency>
         <dependency>
             <packageName>lodash</packageName>
-            <version>1.3.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>lodash</packageName>
             <version>2.1.0</version>
             <licenses>
                 <license>
@@ -2851,16 +2731,6 @@
         <dependency>
             <packageName>lodash</packageName>
             <version>2.2.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>lodash</packageName>
-            <version>2.4.1</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -3030,16 +2900,6 @@
         </dependency>
         <dependency>
             <packageName>mime-db</packageName>
-            <version>1.24.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>mime-db</packageName>
             <version>1.26.0</version>
             <licenses>
                 <license>
@@ -3069,8 +2929,8 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>mime-types</packageName>
-            <version>2.0.14</version>
+            <packageName>mime-db</packageName>
+            <version>1.36.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -3080,7 +2940,7 @@
         </dependency>
         <dependency>
             <packageName>mime-types</packageName>
-            <version>2.1.12</version>
+            <version>2.0.14</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -3119,6 +2979,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>mime-types</packageName>
+            <version>2.1.20</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>mime</packageName>
             <version>1.4.1</version>
             <licenses>
@@ -3145,16 +3015,6 @@
                 <license>
                     <name>ISC License</name>
                     <url>http://www.isc.org/software/license</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>minimist</packageName>
-            <version>0.0.10</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
                 </license>
             </licenses>
         </dependency>
@@ -3420,7 +3280,7 @@
         </dependency>
         <dependency>
             <packageName>mongoose-validator</packageName>
-            <version>1.2.5</version>
+            <version>1.3.2</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -3541,6 +3401,16 @@
         <dependency>
             <packageName>muri</packageName>
             <version>1.2.2</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>mv-lite</packageName>
+            <version>1.0.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -3769,6 +3639,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>oauth-sign</packageName>
+            <version>0.9.0</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>object-assign</packageName>
             <version>4.1.0</version>
             <licenses>
@@ -3815,16 +3695,6 @@
                 <license>
                     <name>ISC License</name>
                     <url>http://www.isc.org/software/license</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>optimist</packageName>
-            <version>0.3.7</version>
-            <licenses>
-                <license>
-                    <name>UNKNOWN</name>
-                    <url>UNKNOWN</url>
                 </license>
             </licenses>
         </dependency>
@@ -4070,16 +3940,6 @@
         </dependency>
         <dependency>
             <packageName>proxy-addr</packageName>
-            <version>2.0.2</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>proxy-addr</packageName>
             <version>2.0.3</version>
             <licenses>
                 <license>
@@ -4095,6 +3955,16 @@
                 <license>
                     <name>ISC License</name>
                     <url>http://www.isc.org/software/license</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>psl</packageName>
+            <version>1.1.29</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
                 </license>
             </licenses>
         </dependency>
@@ -4120,16 +3990,6 @@
         </dependency>
         <dependency>
             <packageName>qs</packageName>
-            <version>6.3.0</version>
-            <licenses>
-                <license>
-                    <name>BSD 3-clause "New" or "Revised" License</name>
-                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>qs</packageName>
             <version>6.4.0</version>
             <licenses>
                 <license>
@@ -4141,6 +4001,16 @@
         <dependency>
             <packageName>qs</packageName>
             <version>6.5.1</version>
+            <licenses>
+                <license>
+                    <name>BSD 3-clause "New" or "Revised" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>qs</packageName>
+            <version>6.5.2</version>
             <licenses>
                 <license>
                     <name>BSD 3-clause "New" or "Revised" License</name>
@@ -4175,16 +4045,6 @@
                 <license>
                     <name>MIT License</name>
                     <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>rc</packageName>
-            <version>0.1.1</version>
-            <licenses>
-                <license>
-                    <name>UNKNOWN</name>
-                    <url>UNKNOWN</url>
                 </license>
             </licenses>
         </dependency>
@@ -4303,16 +4163,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>redis</packageName>
-            <version>0.8.2</version>
-            <licenses>
-                <license>
-                    <name>UNKNOWN</name>
-                    <url>UNKNOWN</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>regexp-clone</packageName>
             <version>0.0.1</version>
             <licenses>
@@ -4364,16 +4214,6 @@
         </dependency>
         <dependency>
             <packageName>request</packageName>
-            <version>2.78.0</version>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>request</packageName>
             <version>2.81.0</version>
             <licenses>
                 <license>
@@ -4395,6 +4235,16 @@
         <dependency>
             <packageName>request</packageName>
             <version>2.87.0</version>
+            <licenses>
+                <license>
+                    <name>Apache License 2.0</name>
+                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
+            <packageName>request</packageName>
+            <version>2.88.0</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -4565,16 +4415,6 @@
         <dependency>
             <packageName>semver</packageName>
             <version>5.3.0</version>
-            <licenses>
-                <license>
-                    <name>ISC License</name>
-                    <url>http://www.isc.org/software/license</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>semver</packageName>
-            <version>5.4.1</version>
             <licenses>
                 <license>
                     <name>ISC License</name>
@@ -4813,6 +4653,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>source-map</packageName>
+            <version>0.6.1</version>
+            <licenses>
+                <license>
+                    <name>BSD 3-clause "New" or "Revised" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>spdx-correct</packageName>
             <version>1.0.2</version>
             <licenses>
@@ -5017,16 +4867,6 @@
             </licenses>
         </dependency>
         <dependency>
-            <packageName>strip-ansi</packageName>
-            <version>3.0.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
             <packageName>strip-bom</packageName>
             <version>2.0.0</version>
             <licenses>
@@ -5059,16 +4899,6 @@
         <dependency>
             <packageName>strip-json-comments</packageName>
             <version>2.0.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>supports-color</packageName>
-            <version>2.0.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -5167,22 +4997,22 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>tough-cookie</packageName>
+            <version>2.4.3</version>
+            <licenses>
+                <license>
+                    <name>BSD 3-clause "New" or "Revised" License</name>
+                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>trim-newlines</packageName>
             <version>1.0.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
                     <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>tunnel-agent</packageName>
-            <version>0.4.3</version>
-            <licenses>
-                <license>
-                    <name>Apache License 2.0</name>
-                    <url>http://www.apache.org/licenses/LICENSE-2.0</url>
                 </license>
             </licenses>
         </dependency>
@@ -5219,16 +5049,6 @@
         <dependency>
             <packageName>type-is</packageName>
             <version>1.5.7</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>type-is</packageName>
-            <version>1.6.15</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -5397,6 +5217,16 @@
             </licenses>
         </dependency>
         <dependency>
+            <packageName>uuid</packageName>
+            <version>3.3.2</version>
+            <licenses>
+                <license>
+                    <name>MIT License</name>
+                    <url>http://www.opensource.org/licenses/MIT</url>
+                </license>
+            </licenses>
+        </dependency>
+        <dependency>
             <packageName>validate-npm-package-license</packageName>
             <version>3.0.1</version>
             <licenses>
@@ -5408,7 +5238,7 @@
         </dependency>
         <dependency>
             <packageName>validator</packageName>
-            <version>4.9.0</version>
+            <version>7.2.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -5488,7 +5318,7 @@
         </dependency>
         <dependency>
             <packageName>winston</packageName>
-            <version>2.4.3</version>
+            <version>2.4.4</version>
             <licenses>
                 <license>
                     <name>MIT License</name>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.12-BUILD-NUMBER",
+  "version": "6.0.13-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -22,6 +22,11 @@
       "from": "ajv@^5.1.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz"
     },
+    "align-text": {
+      "version": "0.1.4",
+      "from": "align-text@>=0.1.3 <0.2.0",
+      "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz"
+    },
     "amdefine": {
       "version": "1.0.1",
       "from": "amdefine@>=0.0.4",
@@ -207,10 +212,36 @@
       "from": "bytes@3.0.0",
       "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.0.0.tgz"
     },
+    "camelcase": {
+      "version": "1.2.1",
+      "from": "camelcase@>=1.0.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-1.2.1.tgz",
+      "optional": true
+    },
     "caseless": {
       "version": "0.12.0",
       "from": "caseless@~0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
+    },
+    "center-align": {
+      "version": "0.1.3",
+      "from": "center-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
+      "optional": true
+    },
+    "cliui": {
+      "version": "2.1.0",
+      "from": "cliui@>=2.1.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
+      "optional": true,
+      "dependencies": {
+        "wordwrap": {
+          "version": "0.0.2",
+          "from": "wordwrap@0.0.2",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-0.0.2.tgz",
+          "optional": true
+        }
+      }
     },
     "co": {
       "version": "4.6.0",
@@ -345,6 +376,11 @@
       "version": "2.6.9",
       "from": "debug@2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz"
+    },
+    "decamelize": {
+      "version": "1.2.0",
+      "from": "decamelize@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/decamelize/-/decamelize-1.2.0.tgz"
     },
     "deep-extend": {
       "version": "0.2.11",
@@ -1863,13 +1899,13 @@
                     "mkdirp": {
                       "version": "0.5.1",
                       "from": "mkdirp@https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                       "optional": true,
                       "dependencies": {
                         "minimist": {
                           "version": "0.0.8",
                           "from": "minimist@https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                          "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                           "optional": true
                         }
                       }
@@ -1883,7 +1919,7 @@
                     "rimraf": {
                       "version": "2.4.5",
                       "from": "rimraf@https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
-                      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
+                      "resolved": "http://registry.npmjs.org/rimraf/-/rimraf-2.4.5.tgz",
                       "optional": true,
                       "dependencies": {
                         "glob": {
@@ -1943,7 +1979,7 @@
                             "once": {
                               "version": "1.3.3",
                               "from": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
-                              "resolved": "http://registry.npmjs.org/once/-/once-1.3.3.tgz",
+                              "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
                               "dependencies": {
                                 "wrappy": {
                                   "version": "1.0.2",
@@ -2374,363 +2410,64 @@
       }
     },
     "fh-messaging-client": {
-      "version": "1.0.4",
-      "from": "fh-messaging-client@1.0.4",
-      "resolved": "https://registry.npmjs.org/fh-messaging-client/-/fh-messaging-client-1.0.4.tgz",
+      "version": "1.0.5",
+      "from": "fh-messaging-client@1.0.5",
+      "resolved": "https://registry.npmjs.org/fh-messaging-client/-/fh-messaging-client-1.0.5.tgz",
       "dependencies": {
+        "aws4": {
+          "version": "1.8.0",
+          "from": "aws4@>=1.8.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
+        },
+        "extend": {
+          "version": "3.0.2",
+          "from": "extend@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
+        },
+        "har-validator": {
+          "version": "5.1.0",
+          "from": "har-validator@>=5.1.0 <5.2.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz"
+        },
+        "mime-db": {
+          "version": "1.36.0",
+          "from": "mime-db@>=1.36.0 <1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz"
+        },
+        "mime-types": {
+          "version": "2.1.20",
+          "from": "mime-types@>=2.1.19 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz"
+        },
+        "oauth-sign": {
+          "version": "0.9.0",
+          "from": "oauth-sign@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
+        },
+        "qs": {
+          "version": "6.5.2",
+          "from": "qs@>=6.5.2 <6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
+        },
         "request": {
-          "version": "2.78.0",
-          "from": "request@>=2.78.0 <3.0.0",
-          "resolved": "http://registry.npmjs.org/request/-/request-2.78.0.tgz",
-          "dependencies": {
-            "aws-sign2": {
-              "version": "0.6.0",
-              "from": "aws-sign2@>=0.6.0 <0.7.0",
-              "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
-            },
-            "aws4": {
-              "version": "1.5.0",
-              "from": "aws4@>=1.2.1 <2.0.0",
-              "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.5.0.tgz"
-            },
-            "caseless": {
-              "version": "0.11.0",
-              "from": "caseless@>=0.11.0 <0.12.0",
-              "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.11.0.tgz"
-            },
-            "combined-stream": {
-              "version": "1.0.5",
-              "from": "combined-stream@>=1.0.5 <1.1.0",
-              "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz",
-              "dependencies": {
-                "delayed-stream": {
-                  "version": "1.0.0",
-                  "from": "delayed-stream@>=1.0.0 <1.1.0",
-                  "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-                }
-              }
-            },
-            "extend": {
-              "version": "3.0.0",
-              "from": "extend@>=3.0.0 <3.1.0",
-              "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
-            },
-            "forever-agent": {
-              "version": "0.6.1",
-              "from": "forever-agent@>=0.6.1 <0.7.0",
-              "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-            },
-            "form-data": {
-              "version": "2.1.2",
-              "from": "form-data@>=2.1.1 <2.2.0",
-              "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.1.2.tgz",
-              "dependencies": {
-                "asynckit": {
-                  "version": "0.4.0",
-                  "from": "asynckit@>=0.4.0 <0.5.0",
-                  "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-                }
-              }
-            },
-            "har-validator": {
-              "version": "2.0.6",
-              "from": "har-validator@>=2.0.6 <2.1.0",
-              "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-2.0.6.tgz",
-              "dependencies": {
-                "chalk": {
-                  "version": "1.1.3",
-                  "from": "chalk@>=1.1.1 <2.0.0",
-                  "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-                  "dependencies": {
-                    "ansi-styles": {
-                      "version": "2.2.1",
-                      "from": "ansi-styles@>=2.2.1 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz"
-                    },
-                    "escape-string-regexp": {
-                      "version": "1.0.5",
-                      "from": "escape-string-regexp@>=1.0.2 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
-                    },
-                    "has-ansi": {
-                      "version": "2.0.0",
-                      "from": "has-ansi@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "strip-ansi": {
-                      "version": "3.0.1",
-                      "from": "strip-ansi@>=3.0.0 <4.0.0",
-                      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-                      "dependencies": {
-                        "ansi-regex": {
-                          "version": "2.0.0",
-                          "from": "ansi-regex@>=2.0.0 <3.0.0",
-                          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.0.0.tgz"
-                        }
-                      }
-                    },
-                    "supports-color": {
-                      "version": "2.0.0",
-                      "from": "supports-color@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz"
-                    }
-                  }
-                },
-                "commander": {
-                  "version": "2.9.0",
-                  "from": "commander@>=2.9.0 <3.0.0",
-                  "resolved": "http://registry.npmjs.org/commander/-/commander-2.9.0.tgz",
-                  "dependencies": {
-                    "graceful-readlink": {
-                      "version": "1.0.1",
-                      "from": "graceful-readlink@>=1.0.0",
-                      "resolved": "https://registry.npmjs.org/graceful-readlink/-/graceful-readlink-1.0.1.tgz"
-                    }
-                  }
-                },
-                "is-my-json-valid": {
-                  "version": "2.15.0",
-                  "from": "is-my-json-valid@>=2.12.4 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/is-my-json-valid/-/is-my-json-valid-2.15.0.tgz",
-                  "dependencies": {
-                    "generate-function": {
-                      "version": "2.0.0",
-                      "from": "generate-function@>=2.0.0 <3.0.0",
-                      "resolved": "http://registry.npmjs.org/generate-function/-/generate-function-2.0.0.tgz"
-                    },
-                    "generate-object-property": {
-                      "version": "1.2.0",
-                      "from": "generate-object-property@>=1.1.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz",
-                      "dependencies": {
-                        "is-property": {
-                          "version": "1.0.2",
-                          "from": "is-property@>=1.0.0 <2.0.0",
-                          "resolved": "https://registry.npmjs.org/is-property/-/is-property-1.0.2.tgz"
-                        }
-                      }
-                    },
-                    "jsonpointer": {
-                      "version": "4.0.0",
-                      "from": "jsonpointer@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.0.tgz"
-                    },
-                    "xtend": {
-                      "version": "4.0.1",
-                      "from": "xtend@>=4.0.0 <5.0.0",
-                      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz"
-                    }
-                  }
-                },
-                "pinkie-promise": {
-                  "version": "2.0.1",
-                  "from": "pinkie-promise@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
-                  "dependencies": {
-                    "pinkie": {
-                      "version": "2.0.4",
-                      "from": "pinkie@>=2.0.0 <3.0.0",
-                      "resolved": "https://registry.npmjs.org/pinkie/-/pinkie-2.0.4.tgz"
-                    }
-                  }
-                }
-              }
-            },
-            "hawk": {
-              "version": "3.1.3",
-              "from": "hawk@>=3.1.3 <3.2.0",
-              "resolved": "https://registry.npmjs.org/hawk/-/hawk-3.1.3.tgz",
-              "dependencies": {
-                "boom": {
-                  "version": "2.10.1",
-                  "from": "boom@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/boom/-/boom-2.10.1.tgz"
-                },
-                "cryptiles": {
-                  "version": "2.0.5",
-                  "from": "cryptiles@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-2.0.5.tgz"
-                },
-                "hoek": {
-                  "version": "2.16.3",
-                  "from": "hoek@>=2.0.0 <3.0.0",
-                  "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
-                },
-                "sntp": {
-                  "version": "1.0.9",
-                  "from": "sntp@>=1.0.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sntp/-/sntp-1.0.9.tgz"
-                }
-              }
-            },
-            "http-signature": {
-              "version": "1.1.1",
-              "from": "http-signature@>=1.1.0 <1.2.0",
-              "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.1.1.tgz",
-              "dependencies": {
-                "assert-plus": {
-                  "version": "0.2.0",
-                  "from": "assert-plus@>=0.2.0 <0.3.0",
-                  "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-0.2.0.tgz"
-                },
-                "jsprim": {
-                  "version": "1.3.1",
-                  "from": "jsprim@>=1.2.2 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.3.1.tgz",
-                  "dependencies": {
-                    "extsprintf": {
-                      "version": "1.0.2",
-                      "from": "extsprintf@1.0.2",
-                      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.0.2.tgz"
-                    },
-                    "json-schema": {
-                      "version": "0.2.3",
-                      "from": "json-schema@0.2.3",
-                      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-                    },
-                    "verror": {
-                      "version": "1.3.6",
-                      "from": "verror@1.3.6",
-                      "resolved": "https://registry.npmjs.org/verror/-/verror-1.3.6.tgz"
-                    }
-                  }
-                },
-                "sshpk": {
-                  "version": "1.10.1",
-                  "from": "sshpk@>=1.7.0 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.10.1.tgz",
-                  "dependencies": {
-                    "asn1": {
-                      "version": "0.2.3",
-                      "from": "asn1@>=0.2.3 <0.3.0",
-                      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-                    },
-                    "assert-plus": {
-                      "version": "1.0.0",
-                      "from": "assert-plus@>=1.0.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-                    },
-                    "bcrypt-pbkdf": {
-                      "version": "1.0.0",
-                      "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.0.tgz",
-                      "optional": true
-                    },
-                    "dashdash": {
-                      "version": "1.14.0",
-                      "from": "dashdash@>=1.12.0 <2.0.0",
-                      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.0.tgz"
-                    },
-                    "ecc-jsbn": {
-                      "version": "0.1.1",
-                      "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-                      "optional": true
-                    },
-                    "getpass": {
-                      "version": "0.1.6",
-                      "from": "getpass@>=0.1.1 <0.2.0",
-                      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.6.tgz"
-                    },
-                    "jodid25519": {
-                      "version": "1.0.2",
-                      "from": "jodid25519@https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz",
-                      "optional": true
-                    },
-                    "jsbn": {
-                      "version": "0.1.0",
-                      "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.0.tgz",
-                      "optional": true
-                    },
-                    "tweetnacl": {
-                      "version": "0.14.3",
-                      "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.3.tgz",
-                      "optional": true
-                    }
-                  }
-                }
-              }
-            },
-            "is-typedarray": {
-              "version": "1.0.0",
-              "from": "is-typedarray@>=1.0.0 <1.1.0",
-              "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-            },
-            "isstream": {
-              "version": "0.1.2",
-              "from": "isstream@>=0.1.2 <0.2.0",
-              "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-            },
-            "json-stringify-safe": {
-              "version": "5.0.1",
-              "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-              "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-            },
-            "mime-types": {
-              "version": "2.1.12",
-              "from": "mime-types@>=2.1.7 <2.2.0",
-              "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.12.tgz",
-              "dependencies": {
-                "mime-db": {
-                  "version": "1.24.0",
-                  "from": "mime-db@>=1.24.0 <1.25.0",
-                  "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.24.0.tgz"
-                }
-              }
-            },
-            "node-uuid": {
-              "version": "1.4.7",
-              "from": "node-uuid@>=1.4.7 <1.5.0",
-              "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
-            },
-            "oauth-sign": {
-              "version": "0.8.2",
-              "from": "oauth-sign@>=0.8.1 <0.9.0",
-              "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-            },
-            "qs": {
-              "version": "6.3.0",
-              "from": "qs@>=6.3.0 <6.4.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-6.3.0.tgz"
-            },
-            "stringstream": {
-              "version": "0.0.5",
-              "from": "stringstream@>=0.0.4 <0.1.0",
-              "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
-            },
-            "tough-cookie": {
-              "version": "2.3.2",
-              "from": "tough-cookie@>=2.3.0 <2.4.0",
-              "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.2.tgz",
-              "dependencies": {
-                "punycode": {
-                  "version": "1.4.1",
-                  "from": "punycode@>=1.4.1 <2.0.0",
-                  "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
-                }
-              }
-            },
-            "tunnel-agent": {
-              "version": "0.4.3",
-              "from": "tunnel-agent@>=0.4.1 <0.5.0",
-              "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.4.3.tgz"
-            }
-          }
+          "version": "2.88.0",
+          "from": "request@2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz"
+        },
+        "tough-cookie": {
+          "version": "2.4.3",
+          "from": "tough-cookie@>=2.4.3 <2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz"
         },
         "underscore": {
           "version": "1.8.0",
           "from": "underscore@1.8.0",
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz"
+        },
+        "uuid": {
+          "version": "3.3.2",
+          "from": "uuid@>=3.3.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
         }
       }
     },
@@ -3559,6 +3296,11 @@
       "from": "is@^3.2.1",
       "resolved": "https://registry.npmjs.org/is/-/is-3.2.1.tgz"
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "from": "is-buffer@>=1.1.5 <2.0.0",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz"
+    },
     "is-stream": {
       "version": "1.1.0",
       "from": "is-stream@^1.0.1",
@@ -3631,10 +3373,21 @@
       "from": "kew@^0.7.0",
       "resolved": "https://registry.npmjs.org/kew/-/kew-0.7.0.tgz"
     },
+    "kind-of": {
+      "version": "3.2.2",
+      "from": "kind-of@>=3.0.2 <4.0.0",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz"
+    },
     "klaw": {
       "version": "1.3.1",
       "from": "klaw@^1.0.0",
       "resolved": "https://registry.npmjs.org/klaw/-/klaw-1.3.1.tgz"
+    },
+    "lazy-cache": {
+      "version": "1.0.4",
+      "from": "lazy-cache@>=1.0.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
+      "optional": true
     },
     "lazystream": {
       "version": "1.0.0",
@@ -3697,6 +3450,11 @@
       "version": "4.3.2",
       "from": "lodash.set@^4.3.2",
       "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz"
+    },
+    "longest": {
+      "version": "1.0.1",
+      "from": "longest@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz"
     },
     "lru-cache": {
       "version": "4.1.3",
@@ -4324,6 +4082,11 @@
       "from": "remove-trailing-separator@^1.0.1",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz"
     },
+    "repeat-string": {
+      "version": "1.6.1",
+      "from": "repeat-string@>=1.5.2 <2.0.0",
+      "resolved": "https://registry.npmjs.org/repeat-string/-/repeat-string-1.6.1.tgz"
+    },
     "request": {
       "version": "2.87.0",
       "from": "request@2.87.0",
@@ -4348,6 +4111,12 @@
       "version": "2.0.0",
       "from": "resolve-from@^2.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz"
+    },
+    "right-align": {
+      "version": "0.1.3",
+      "from": "right-align@>=0.1.1 <0.2.0",
+      "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
+      "optional": true
     },
     "rimraf": {
       "version": "2.6.2",
@@ -4575,6 +4344,26 @@
       "from": "typedarray@^0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
     },
+    "uglify-js": {
+      "version": "2.8.29",
+      "from": "uglify-js@>=2.6.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
+      "optional": true,
+      "dependencies": {
+        "source-map": {
+          "version": "0.5.7",
+          "from": "source-map@>=0.5.1 <0.6.0",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+          "optional": true
+        }
+      }
+    },
+    "uglify-to-browserify": {
+      "version": "1.0.2",
+      "from": "uglify-to-browserify@>=1.0.0 <1.1.0",
+      "resolved": "https://registry.npmjs.org/uglify-to-browserify/-/uglify-to-browserify-1.0.2.tgz",
+      "optional": true
+    },
     "underscore": {
       "version": "1.9.1",
       "from": "underscore@1.9.1",
@@ -4630,6 +4419,12 @@
       "from": "which@^1.2.10",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz"
     },
+    "window-size": {
+      "version": "0.1.0",
+      "from": "window-size@0.1.0",
+      "resolved": "https://registry.npmjs.org/window-size/-/window-size-0.1.0.tgz",
+      "optional": true
+    },
     "winston": {
       "version": "2.4.4",
       "from": "winston@>=2.4.0 <3.0.0",
@@ -4661,6 +4456,12 @@
       "version": "2.1.2",
       "from": "yallist@^2.1.2",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz"
+    },
+    "yargs": {
+      "version": "3.10.0",
+      "from": "yargs@>=3.10.0 <3.11.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
+      "optional": true
     },
     "yauzl": {
       "version": "2.4.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "fh-health": "0.3.3",
     "fh-logger": "0.5.2",
     "fh-mbaas-middleware": "2.3.5",
-    "fh-messaging-client": "1.0.4",
+    "fh-messaging-client": "1.0.5",
     "fh-metrics-client": "1.0.5",
     "fh-service-auth": "1.0.4",
     "mkdirp": "0.5.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.12-BUILD-NUMBER",
+  "version": "6.0.13-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",


### PR DESCRIPTION
# Jira link(s)

https://issues.jboss.org/browse/RHMAP-21740



# What
- Upgrade minor version of fh-messaging-client ( 1.0.4 to 1.0.5)


# Why
- Get fixed bugs and solve CVEs
- Remove the following warn

<img width="921" alt="screen shot 2018-10-03 at 16 43 18" src="https://user-images.githubusercontent.com/7708031/46422393-2fd86780-c72c-11e8-99d2-ccc0bab21ea8.png">

# Verification Steps
Check if CI finish with success. 

## Checklist:

- [x] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
