### PR TITLE
Upgrade fh-metrics-client to 1.0.6 ( minor version bumped )

### DIFF
--- a/licenses/STRING_DECODER_MIT.TXT
+++ b/licenses/STRING_DECODER_MIT.TXT
@@ -1,24 +1,24 @@
-Node.js is licensed for use as follows:
+Copyright Joyent, Inc. and other Node contributors.
 
-"""
-Copyright Node.js contributors. All rights reserved.
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to permit
+persons to whom the Software is furnished to do so, subject to the
+following conditions:
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to
-deal in the Software without restriction, including without limitation the
-rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
-sell copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
 
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+USE OR OTHER DEALINGS IN THE SOFTWARE.
+OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
 

--- a/licenses/UNDERSCORE_MIT.TXT
+++ b/licenses/UNDERSCORE_MIT.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -44,13 +44,6 @@
 <tr>
 <td>N/A</td>
 <td>ajv</td>
-<td>5.5.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=AJV_MIT.TXT>AJV_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>ajv</td>
 <td>5.5.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=AJV_MIT.TXT>AJV_MIT.TXT</a></td>
@@ -996,14 +989,14 @@
 <tr>
 <td>N/A</td>
 <td>express</td>
-<td>4.16.0</td>
+<td>4.16.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=EXPRESS_MIT.TXT>EXPRESS_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>express</td>
-<td>4.16.3</td>
+<td>4.16.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=EXPRESS_MIT.TXT>EXPRESS_MIT.TXT</a></td>
 </tr>
@@ -1024,7 +1017,7 @@
 <tr>
 <td>N/A</td>
 <td>extend</td>
-<td>3.0.1</td>
+<td>3.0.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=EXTEND_MIT.TXT>EXTEND_MIT.TXT</a></td>
 </tr>
@@ -1038,7 +1031,7 @@
 <tr>
 <td>N/A</td>
 <td>extend</td>
-<td>3.0.2</td>
+<td>3.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=EXTEND_MIT.TXT>EXTEND_MIT.TXT</a></td>
 </tr>
@@ -1052,16 +1045,16 @@
 <tr>
 <td>N/A</td>
 <td>extsprintf</td>
-<td>1.0.2</td>
-<td>UNKNOWN</td>
-<td><a href=EXTSPRINTF_MIT*.TXT>EXTSPRINTF_MIT*.TXT</a></td>
+<td>1.3.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=EXTSPRINTF_MIT.TXT>EXTSPRINTF_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>extsprintf</td>
-<td>1.3.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=EXTSPRINTF_MIT.TXT>EXTSPRINTF_MIT.TXT</a></td>
+<td>1.0.2</td>
+<td>UNKNOWN</td>
+<td><a href=EXTSPRINTF_MIT*.TXT>EXTSPRINTF_MIT*.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1076,13 +1069,6 @@
 <td>2.1.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=FALAFEL_MIT.TXT>FALAFEL_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>fast-deep-equal</td>
-<td>1.0.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=FAST-DEEP-EQUAL_MIT.TXT>FAST-DEEP-EQUAL_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -1199,7 +1185,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-mbaas</td>
-<td>6.0.12-BUILD-NUMBER</td>
+<td>6.0.13-BUILD-NUMBER</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS_APACHE-2.0.TXT>FH-MBAAS_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1227,7 +1213,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-metrics-client</td>
-<td>1.0.5</td>
+<td>1.0.6</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-METRICS-CLIENT_APACHE-2.0.TXT>FH-METRICS-CLIENT_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1283,7 +1269,7 @@
 <tr>
 <td>N/A</td>
 <td>form-data</td>
-<td>2.3.1</td>
+<td>2.3.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=FORM-DATA_MIT.TXT>FORM-DATA_MIT.TXT</a></td>
 </tr>
@@ -1291,13 +1277,6 @@
 <td>N/A</td>
 <td>form-data</td>
 <td>2.1.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=FORM-DATA_MIT.TXT>FORM-DATA_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>form-data</td>
-<td>2.3.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=FORM-DATA_MIT.TXT>FORM-DATA_MIT.TXT</a></td>
 </tr>
@@ -1486,13 +1465,6 @@
 <tr>
 <td>N/A</td>
 <td>hoek</td>
-<td>4.2.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=HOEK_BSD-3-CLAUSE.TXT>HOEK_BSD-3-CLAUSE.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>hoek</td>
 <td>2.16.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=HOEK_BSD-3-CLAUSE.TXT>HOEK_BSD-3-CLAUSE.TXT</a></td>
@@ -1577,14 +1549,14 @@
 <tr>
 <td>N/A</td>
 <td>iconv-lite</td>
-<td>0.4.13</td>
+<td>0.2.11</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ICONV-LITE_MIT.TXT>ICONV-LITE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>iconv-lite</td>
-<td>0.2.11</td>
+<td>0.4.13</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=ICONV-LITE_MIT.TXT>ICONV-LITE_MIT.TXT</a></td>
 </tr>
@@ -2046,6 +2018,20 @@
 <tr>
 <td>N/A</td>
 <td>mime-db</td>
+<td>1.36.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
+<td>1.12.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-db</td>
 <td>1.26.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
@@ -2059,43 +2045,8 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>mime-db</td>
-<td>1.36.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-db</td>
-<td>1.30.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-db</td>
-<td>1.12.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-DB_MIT.TXT>MIME-DB_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>mime-types</td>
-<td>2.0.14</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-types</td>
-<td>2.1.14</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mime-types</td>
-<td>2.1.17</td>
+<td>2.1.20</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
@@ -2109,7 +2060,14 @@
 <tr>
 <td>N/A</td>
 <td>mime-types</td>
-<td>2.1.20</td>
+<td>2.1.14</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mime-types</td>
+<td>2.0.14</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MIME-TYPES_MIT.TXT>MIME-TYPES_MIT.TXT</a></td>
 </tr>
@@ -2130,14 +2088,14 @@
 <tr>
 <td>N/A</td>
 <td>minimist</td>
-<td>1.2.0</td>
+<td>0.0.8</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MINIMIST_MIT.TXT>MINIMIST_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>minimist</td>
-<td>0.0.8</td>
+<td>1.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MINIMIST_MIT.TXT>MINIMIST_MIT.TXT</a></td>
 </tr>
@@ -2172,13 +2130,6 @@
 <tr>
 <td>N/A</td>
 <td>moment</td>
-<td>2.19.3</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MOMENT_MIT.TXT>MOMENT_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>moment</td>
 <td>2.19.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MOMENT_MIT.TXT>MOMENT_MIT.TXT</a></td>
@@ -2193,6 +2144,13 @@
 <tr>
 <td>N/A</td>
 <td>moment</td>
+<td>2.15.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MOMENT_MIT.TXT>MOMENT_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>moment</td>
 <td>2.13.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MOMENT_MIT.TXT>MOMENT_MIT.TXT</a></td>
@@ -2200,7 +2158,7 @@
 <tr>
 <td>N/A</td>
 <td>moment</td>
-<td>2.15.2</td>
+<td>2.19.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MOMENT_MIT.TXT>MOMENT_MIT.TXT</a></td>
 </tr>
@@ -2249,7 +2207,14 @@
 <tr>
 <td>N/A</td>
 <td>mongodb-core</td>
-<td>2.1.15</td>
+<td>1.3.10</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>mongodb-core</td>
+<td>2.1.19</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
 </tr>
@@ -2263,14 +2228,7 @@
 <tr>
 <td>N/A</td>
 <td>mongodb-core</td>
-<td>1.3.10</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mongodb-core</td>
-<td>2.1.19</td>
+<td>2.1.15</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=MONGODB-CORE_APACHE-2.0.TXT>MONGODB-CORE_APACHE-2.0.TXT</a></td>
 </tr>
@@ -2333,28 +2291,28 @@
 <tr>
 <td>N/A</td>
 <td>mpath</td>
-<td>0.3.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=MPATH_MIT.TXT>MPATH_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>mpath</td>
 <td>0.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MPATH_MIT.TXT>MPATH_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
+<td>mpath</td>
+<td>0.3.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=MPATH_MIT.TXT>MPATH_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
 <td>mpromise</td>
-<td>0.5.5</td>
+<td>0.2.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MPROMISE_MIT.TXT>MPROMISE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>mpromise</td>
-<td>0.2.1</td>
+<td>0.5.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=MPROMISE_MIT.TXT>MPROMISE_MIT.TXT</a></td>
 </tr>
@@ -2683,14 +2641,14 @@
 <tr>
 <td>N/A</td>
 <td>performance-now</td>
-<td>0.2.0</td>
+<td>2.1.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=PERFORMANCE-NOW_MIT.TXT>PERFORMANCE-NOW_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>performance-now</td>
-<td>2.1.0</td>
+<td>0.2.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=PERFORMANCE-NOW_MIT.TXT>PERFORMANCE-NOW_MIT.TXT</a></td>
 </tr>
@@ -2802,14 +2760,14 @@
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>6.5.1</td>
+<td>6.4.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>6.4.0</td>
+<td>6.5.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -2823,7 +2781,7 @@
 <tr>
 <td>N/A</td>
 <td>qs</td>
-<td>6.5.2</td>
+<td>6.5.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=QS_BSD-3-CLAUSE.TXT>QS_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -2859,14 +2817,14 @@
 <td>N/A</td>
 <td>rc</td>
 <td>1.2.8</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
 <td><a href=RC_(BSD-2-CLAUSE%20OR%20MIT%20OR%20APACHE-2.0).TXT>RC_(BSD-2-CLAUSE OR MIT OR APACHE-2.0).TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>rc</td>
 <td>1.2.8</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-2-Clause</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=RC_(BSD-2-CLAUSE%20OR%20MIT%20OR%20APACHE-2.0).TXT>RC_(BSD-2-CLAUSE OR MIT OR APACHE-2.0).TXT</a></td>
 </tr>
 <tr>
@@ -2886,14 +2844,7 @@
 <tr>
 <td>N/A</td>
 <td>readable-stream</td>
-<td>1.0.34</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>readable-stream</td>
-<td>1.1.14</td>
+<td>1.0.31</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
 </tr>
@@ -2921,7 +2872,14 @@
 <tr>
 <td>N/A</td>
 <td>readable-stream</td>
-<td>1.0.31</td>
+<td>1.0.34</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>readable-stream</td>
+<td>1.1.14</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=READABLE-STREAM_MIT.TXT>READABLE-STREAM_MIT.TXT</a></td>
 </tr>
@@ -2963,14 +2921,7 @@
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.83.0</td>
-<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
-<td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>request</td>
-<td>2.87.0</td>
+<td>2.88.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
@@ -2984,7 +2935,14 @@
 <tr>
 <td>N/A</td>
 <td>request</td>
-<td>2.88.0</td>
+<td>2.83.0</td>
+<td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
+<td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>request</td>
+<td>2.87.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=REQUEST_APACHE-2.0.TXT>REQUEST_APACHE-2.0.TXT</a></td>
 </tr>
@@ -3033,16 +2991,16 @@
 <tr>
 <td>N/A</td>
 <td>rimraf</td>
-<td>2.2.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=RIMRAF_MIT.TXT>RIMRAF_MIT.TXT</a></td>
+<td>2.6.2</td>
+<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
+<td><a href=RIMRAF_ISC.TXT>RIMRAF_ISC.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>rimraf</td>
-<td>2.6.2</td>
-<td>http:&#x2F;&#x2F;www.isc.org&#x2F;software&#x2F;license</td>
-<td><a href=RIMRAF_ISC.TXT>RIMRAF_ISC.TXT</a></td>
+<td>2.2.2</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=RIMRAF_MIT.TXT>RIMRAF_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3068,13 +3026,6 @@
 <tr>
 <td>N/A</td>
 <td>safe-json-stringify</td>
-<td>1.0.3</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>safe-json-stringify</td>
 <td>1.0.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
@@ -3083,6 +3034,13 @@
 <td>N/A</td>
 <td>safe-json-stringify</td>
 <td>1.2.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=#>No local license could be found for the dependency</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>safe-json-stringify</td>
+<td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
@@ -3124,14 +3082,14 @@
 <tr>
 <td>N/A</td>
 <td>send</td>
-<td>0.16.2</td>
+<td>0.16.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SEND_MIT.TXT>SEND_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>send</td>
-<td>0.16.0</td>
+<td>0.16.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SEND_MIT.TXT>SEND_MIT.TXT</a></td>
 </tr>
@@ -3145,14 +3103,14 @@
 <tr>
 <td>N/A</td>
 <td>serve-static</td>
-<td>1.13.0</td>
+<td>1.13.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SERVE-STATIC_MIT.TXT>SERVE-STATIC_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>serve-static</td>
-<td>1.13.2</td>
+<td>1.13.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SERVE-STATIC_MIT.TXT>SERVE-STATIC_MIT.TXT</a></td>
 </tr>
@@ -3201,7 +3159,7 @@
 <tr>
 <td>N/A</td>
 <td>sliced</td>
-<td>0.0.5</td>
+<td>0.0.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
 </tr>
@@ -3215,7 +3173,7 @@
 <tr>
 <td>N/A</td>
 <td>sliced</td>
-<td>0.0.4</td>
+<td>0.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SLICED_MIT.TXT>SLICED_MIT.TXT</a></td>
 </tr>
@@ -3243,16 +3201,16 @@
 <tr>
 <td>N/A</td>
 <td>sntp</td>
-<td>1.0.9</td>
-<td>UNKNOWN</td>
-<td><a href=SNTP_BSD.TXT>SNTP_BSD.TXT</a></td>
+<td>2.1.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=SNTP_BSD-3-CLAUSE.TXT>SNTP_BSD-3-CLAUSE.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>sntp</td>
-<td>2.1.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=SNTP_BSD-3-CLAUSE.TXT>SNTP_BSD-3-CLAUSE.TXT</a></td>
+<td>1.0.9</td>
+<td>UNKNOWN</td>
+<td><a href=SNTP_BSD.TXT>SNTP_BSD.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3320,13 +3278,6 @@
 <tr>
 <td>N/A</td>
 <td>sshpk</td>
-<td>1.13.1</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=SSHPK_MIT.TXT>SSHPK_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>sshpk</td>
 <td>1.14.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=SSHPK_MIT.TXT>SSHPK_MIT.TXT</a></td>
@@ -3341,16 +3292,16 @@
 <tr>
 <td>N/A</td>
 <td>stack-trace</td>
-<td>0.0.10</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=STACK-TRACE_MIT.TXT>STACK-TRACE_MIT.TXT</a></td>
+<td>0.0.9</td>
+<td>UNKNOWN</td>
+<td><a href=STACK-TRACE_MIT*.TXT>STACK-TRACE_MIT*.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>stack-trace</td>
-<td>0.0.9</td>
-<td>UNKNOWN</td>
-<td><a href=STACK-TRACE_MIT*.TXT>STACK-TRACE_MIT*.TXT</a></td>
+<td>0.0.10</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=STACK-TRACE_MIT.TXT>STACK-TRACE_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3369,6 +3320,13 @@
 <tr>
 <td>N/A</td>
 <td>statuses</td>
+<td>1.4.0</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
+<td><a href=STATUSES_MIT.TXT>STATUSES_MIT.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>statuses</td>
 <td>1.3.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STATUSES_MIT.TXT>STATUSES_MIT.TXT</a></td>
@@ -3382,13 +3340,6 @@
 </tr>
 <tr>
 <td>N/A</td>
-<td>statuses</td>
-<td>1.4.0</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=STATUSES_MIT.TXT>STATUSES_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
 <td>streamsearch</td>
 <td>0.1.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
@@ -3397,7 +3348,7 @@
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>1.0.3</td>
+<td>1.1.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>
@@ -3411,21 +3362,21 @@
 <tr>
 <td>N/A</td>
 <td>string_decoder</td>
-<td>1.1.1</td>
+<td>1.0.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRING_DECODER_MIT.TXT>STRING_DECODER_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>stringstream</td>
-<td>0.0.5</td>
+<td>0.0.6</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRINGSTREAM_MIT.TXT>STRINGSTREAM_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>stringstream</td>
-<td>0.0.6</td>
+<td>0.0.5</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=STRINGSTREAM_MIT.TXT>STRINGSTREAM_MIT.TXT</a></td>
 </tr>
@@ -3446,16 +3397,16 @@
 <tr>
 <td>N/A</td>
 <td>strip-json-comments</td>
-<td>0.1.3</td>
+<td>2.0.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=#>No local license could be found for the dependency</a></td>
+<td><a href=STRIP-JSON-COMMENTS_MIT.TXT>STRIP-JSON-COMMENTS_MIT.TXT</a></td>
 </tr>
 <tr>
 <td>N/A</td>
 <td>strip-json-comments</td>
-<td>2.0.1</td>
+<td>0.1.3</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=STRIP-JSON-COMMENTS_MIT.TXT>STRIP-JSON-COMMENTS_MIT.TXT</a></td>
+<td><a href=#>No local license could be found for the dependency</a></td>
 </tr>
 <tr>
 <td>N/A</td>
@@ -3502,20 +3453,6 @@
 <tr>
 <td>N/A</td>
 <td>tough-cookie</td>
-<td>2.3.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>tough-cookie</td>
-<td>2.3.3</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
-<td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>tough-cookie</td>
 <td>2.3.4</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
@@ -3524,6 +3461,13 @@
 <td>N/A</td>
 <td>tough-cookie</td>
 <td>2.4.3</td>
+<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
+<td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
+</tr>
+<tr>
+<td>N/A</td>
+<td>tough-cookie</td>
+<td>2.3.2</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;BSD-3-Clause</td>
 <td><a href=TOUGH-COOKIE_BSD-3-CLAUSE.TXT>TOUGH-COOKIE_BSD-3-CLAUSE.TXT</a></td>
 </tr>
@@ -3600,7 +3544,7 @@
 <tr>
 <td>N/A</td>
 <td>underscore</td>
-<td>1.8.0</td>
+<td>1.9.1</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
 </tr>
@@ -3614,7 +3558,7 @@
 <tr>
 <td>N/A</td>
 <td>underscore</td>
-<td>1.9.1</td>
+<td>1.8.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UNDERSCORE_MIT.TXT>UNDERSCORE_MIT.TXT</a></td>
 </tr>
@@ -3664,13 +3608,6 @@
 <td>N/A</td>
 <td>uuid</td>
 <td>3.3.2</td>
-<td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
-<td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
-</tr>
-<tr>
-<td>N/A</td>
-<td>uuid</td>
-<td>3.1.0</td>
 <td>http:&#x2F;&#x2F;www.opensource.org&#x2F;licenses&#x2F;MIT</td>
 <td><a href=UUID_MIT.TXT>UUID_MIT.TXT</a></td>
 </tr>

--- a/licenses/licenses.xml
+++ b/licenses/licenses.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <licenseSummary>
     <project>fh-mbaas</project>
-    <version>6.0.12-BUILD-NUMBER</version>
+    <version>6.0.13-BUILD-NUMBER</version>
     <license>Apache-2.0</license>
     <dependencies>
         <dependency>
@@ -37,16 +37,6 @@
         <dependency>
             <packageName>ajv</packageName>
             <version>4.11.5</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>ajv</packageName>
-            <version>5.5.1</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -1520,16 +1510,6 @@
         </dependency>
         <dependency>
             <packageName>fast-deep-equal</packageName>
-            <version>1.0.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>fast-deep-equal</packageName>
             <version>1.1.0</version>
             <licenses>
                 <license>
@@ -1710,7 +1690,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas</packageName>
-            <version>6.0.12-BUILD-NUMBER</version>
+            <version>6.0.13-BUILD-NUMBER</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1730,7 +1710,7 @@
         </dependency>
         <dependency>
             <packageName>fh-metrics-client</packageName>
-            <version>1.0.5</version>
+            <version>1.0.6</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1811,16 +1791,6 @@
         <dependency>
             <packageName>form-data</packageName>
             <version>2.1.2</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>form-data</packageName>
-            <version>2.3.1</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -2091,16 +2061,6 @@
         <dependency>
             <packageName>hoek</packageName>
             <version>2.16.3</version>
-            <licenses>
-                <license>
-                    <name>BSD 3-clause "New" or "Revised" License</name>
-                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>hoek</packageName>
-            <version>4.2.0</version>
             <licenses>
                 <license>
                     <name>BSD 3-clause "New" or "Revised" License</name>
@@ -2910,16 +2870,6 @@
         </dependency>
         <dependency>
             <packageName>mime-db</packageName>
-            <version>1.30.0</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>mime-db</packageName>
             <version>1.33.0</version>
             <licenses>
                 <license>
@@ -2951,16 +2901,6 @@
         <dependency>
             <packageName>mime-types</packageName>
             <version>2.1.14</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>mime-types</packageName>
-            <version>2.1.17</version>
             <licenses>
                 <license>
                     <name>MIT License</name>
@@ -4718,16 +4658,6 @@
         </dependency>
         <dependency>
             <packageName>sshpk</packageName>
-            <version>1.13.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>sshpk</packageName>
             <version>1.14.2</version>
             <licenses>
                 <license>
@@ -4978,16 +4908,6 @@
         </dependency>
         <dependency>
             <packageName>tough-cookie</packageName>
-            <version>2.3.3</version>
-            <licenses>
-                <license>
-                    <name>BSD 3-clause "New" or "Revised" License</name>
-                    <url>http://www.opensource.org/licenses/BSD-3-Clause</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>tough-cookie</packageName>
             <version>2.3.4</version>
             <licenses>
                 <license>
@@ -5189,16 +5109,6 @@
         <dependency>
             <packageName>uuid</packageName>
             <version>3.0.1</version>
-            <licenses>
-                <license>
-                    <name>MIT License</name>
-                    <url>http://www.opensource.org/licenses/MIT</url>
-                </license>
-            </licenses>
-        </dependency>
-        <dependency>
-            <packageName>uuid</packageName>
-            <version>3.1.0</version>
             <licenses>
                 <license>
                     <name>MIT License</name>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.13-BUILD-NUMBER",
+  "version": "6.0.14-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -762,13 +762,13 @@
                 "mkdirp": {
                   "version": "0.5.1",
                   "from": "mkdirp@http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "optional": true,
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "optional": true
                     }
                   }
@@ -1708,13 +1708,13 @@
                 "mkdirp": {
                   "version": "0.5.1",
                   "from": "mkdirp@http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
-                  "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+                  "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
                   "optional": true,
                   "dependencies": {
                     "minimist": {
                       "version": "0.0.8",
                       "from": "minimist@http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
-                      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+                      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
                       "optional": true
                     }
                   }
@@ -2472,204 +2472,34 @@
       }
     },
     "fh-metrics-client": {
-      "version": "1.0.5",
-      "from": "fh-metrics-client@1.0.5",
-      "resolved": "https://registry.npmjs.org/fh-metrics-client/-/fh-metrics-client-1.0.5.tgz",
+      "version": "1.0.6",
+      "from": "fh-metrics-client@1.0.6",
+      "resolved": "https://registry.npmjs.org/fh-metrics-client/-/fh-metrics-client-1.0.6.tgz",
       "dependencies": {
-        "ajv": {
-          "version": "5.5.1",
-          "from": "ajv@>=5.1.0 <6.0.0",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz"
-        },
-        "asn1": {
-          "version": "0.2.3",
-          "from": "asn1@>=0.2.3 <0.3.0",
-          "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.3.tgz"
-        },
-        "assert-plus": {
-          "version": "1.0.0",
-          "from": "assert-plus@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz"
-        },
-        "asynckit": {
-          "version": "0.4.0",
-          "from": "asynckit@>=0.4.0 <0.5.0",
-          "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz"
-        },
-        "aws-sign2": {
-          "version": "0.7.0",
-          "from": "aws-sign2@>=0.7.0 <0.8.0",
-          "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz"
-        },
         "aws4": {
-          "version": "1.6.0",
-          "from": "aws4@>=1.6.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz"
-        },
-        "bcrypt-pbkdf": {
-          "version": "1.0.1",
-          "from": "bcrypt-pbkdf@https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-          "optional": true
-        },
-        "boom": {
-          "version": "4.3.1",
-          "from": "boom@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz"
-        },
-        "caseless": {
-          "version": "0.12.0",
-          "from": "caseless@>=0.12.0 <0.13.0",
-          "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz"
-        },
-        "co": {
-          "version": "4.6.0",
-          "from": "co@>=4.6.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/co/-/co-4.6.0.tgz"
-        },
-        "combined-stream": {
-          "version": "1.0.5",
-          "from": "combined-stream@>=1.0.5 <1.1.0",
-          "resolved": "http://registry.npmjs.org/combined-stream/-/combined-stream-1.0.5.tgz"
-        },
-        "core-util-is": {
-          "version": "1.0.2",
-          "from": "core-util-is@1.0.2",
-          "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
-        },
-        "cryptiles": {
-          "version": "3.1.2",
-          "from": "cryptiles@>=3.0.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-          "dependencies": {
-            "boom": {
-              "version": "5.2.0",
-              "from": "boom@>=5.0.0 <6.0.0",
-              "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz"
-            }
-          }
-        },
-        "dashdash": {
-          "version": "1.14.1",
-          "from": "dashdash@>=1.12.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz"
-        },
-        "delayed-stream": {
-          "version": "1.0.0",
-          "from": "delayed-stream@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz"
-        },
-        "ecc-jsbn": {
-          "version": "0.1.1",
-          "from": "ecc-jsbn@https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz",
-          "optional": true
+          "version": "1.8.0",
+          "from": "aws4@>=1.8.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz"
         },
         "extend": {
-          "version": "3.0.1",
-          "from": "extend@>=3.0.1 <3.1.0",
-          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.1.tgz"
-        },
-        "extsprintf": {
-          "version": "1.3.0",
-          "from": "extsprintf@1.3.0",
-          "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz"
-        },
-        "fast-deep-equal": {
-          "version": "1.0.0",
-          "from": "fast-deep-equal@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-1.0.0.tgz"
-        },
-        "fast-json-stable-stringify": {
-          "version": "2.0.0",
-          "from": "fast-json-stable-stringify@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz"
-        },
-        "forever-agent": {
-          "version": "0.6.1",
-          "from": "forever-agent@>=0.6.1 <0.7.0",
-          "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz"
-        },
-        "form-data": {
-          "version": "2.3.1",
-          "from": "form-data@>=2.3.1 <2.4.0",
-          "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.1.tgz"
-        },
-        "getpass": {
-          "version": "0.1.7",
-          "from": "getpass@>=0.1.1 <0.2.0",
-          "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz"
-        },
-        "har-schema": {
-          "version": "2.0.0",
-          "from": "har-schema@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz"
+          "version": "3.0.2",
+          "from": "extend@>=3.0.2 <3.1.0",
+          "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz"
         },
         "har-validator": {
-          "version": "5.0.3",
-          "from": "har-validator@>=5.0.3 <5.1.0",
-          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.0.3.tgz"
-        },
-        "hawk": {
-          "version": "6.0.2",
-          "from": "hawk@>=6.0.2 <6.1.0",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz"
-        },
-        "hoek": {
-          "version": "4.2.0",
-          "from": "hoek@>=4.0.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.0.tgz"
-        },
-        "http-signature": {
-          "version": "1.2.0",
-          "from": "http-signature@>=1.2.0 <1.3.0",
-          "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz"
-        },
-        "is-typedarray": {
-          "version": "1.0.0",
-          "from": "is-typedarray@>=1.0.0 <1.1.0",
-          "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz"
-        },
-        "isstream": {
-          "version": "0.1.2",
-          "from": "isstream@>=0.1.2 <0.2.0",
-          "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
-        },
-        "jsbn": {
-          "version": "0.1.1",
-          "from": "jsbn@https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-          "optional": true
-        },
-        "json-schema": {
-          "version": "0.2.3",
-          "from": "json-schema@0.2.3",
-          "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz"
-        },
-        "json-schema-traverse": {
-          "version": "0.3.1",
-          "from": "json-schema-traverse@>=0.3.0 <0.4.0",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.3.1.tgz"
-        },
-        "json-stringify-safe": {
-          "version": "5.0.1",
-          "from": "json-stringify-safe@>=5.0.1 <5.1.0",
-          "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz"
-        },
-        "jsprim": {
-          "version": "1.4.1",
-          "from": "jsprim@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz"
+          "version": "5.1.0",
+          "from": "har-validator@>=5.1.0 <5.2.0",
+          "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.0.tgz"
         },
         "mime-db": {
-          "version": "1.30.0",
-          "from": "mime-db@>=1.30.0 <1.31.0",
-          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.30.0.tgz"
+          "version": "1.36.0",
+          "from": "mime-db@>=1.36.0 <1.37.0",
+          "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.36.0.tgz"
         },
         "mime-types": {
-          "version": "2.1.17",
-          "from": "mime-types@>=2.1.17 <2.2.0",
-          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.17.tgz"
+          "version": "2.1.20",
+          "from": "mime-types@>=2.1.19 <2.2.0",
+          "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.20.tgz"
         },
         "moment": {
           "version": "2.19.3",
@@ -2677,65 +2507,24 @@
           "resolved": "https://registry.npmjs.org/moment/-/moment-2.19.3.tgz"
         },
         "oauth-sign": {
-          "version": "0.8.2",
-          "from": "oauth-sign@>=0.8.2 <0.9.0",
-          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.8.2.tgz"
-        },
-        "performance-now": {
-          "version": "2.1.0",
-          "from": "performance-now@>=2.1.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz"
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "from": "punycode@>=1.4.1 <2.0.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz"
+          "version": "0.9.0",
+          "from": "oauth-sign@>=0.9.0 <0.10.0",
+          "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz"
         },
         "qs": {
-          "version": "6.5.1",
-          "from": "qs@>=6.5.1 <6.6.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz"
+          "version": "6.5.2",
+          "from": "qs@>=6.5.2 <6.6.0",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz"
         },
         "request": {
-          "version": "2.83.0",
-          "from": "request@2.83.0",
-          "resolved": "https://registry.npmjs.org/request/-/request-2.83.0.tgz"
-        },
-        "safe-buffer": {
-          "version": "5.1.1",
-          "from": "safe-buffer@>=5.1.1 <6.0.0",
-          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz"
-        },
-        "sntp": {
-          "version": "2.1.0",
-          "from": "sntp@>=2.0.0 <3.0.0",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz"
-        },
-        "sshpk": {
-          "version": "1.13.1",
-          "from": "sshpk@>=1.7.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.13.1.tgz"
-        },
-        "stringstream": {
-          "version": "0.0.5",
-          "from": "stringstream@>=0.0.5 <0.1.0",
-          "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz"
+          "version": "2.88.0",
+          "from": "request@2.88.0",
+          "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz"
         },
         "tough-cookie": {
-          "version": "2.3.3",
-          "from": "tough-cookie@>=2.3.3 <2.4.0",
-          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.3.tgz"
-        },
-        "tunnel-agent": {
-          "version": "0.6.0",
-          "from": "tunnel-agent@>=0.6.0 <0.7.0",
-          "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz"
-        },
-        "tweetnacl": {
-          "version": "0.14.5",
-          "from": "tweetnacl@https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-          "optional": true
+          "version": "2.4.3",
+          "from": "tough-cookie@>=2.4.3 <2.5.0",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz"
         },
         "underscore": {
           "version": "1.8.0",
@@ -2743,14 +2532,9 @@
           "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.8.0.tgz"
         },
         "uuid": {
-          "version": "3.1.0",
-          "from": "uuid@>=3.1.0 <4.0.0",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.1.0.tgz"
-        },
-        "verror": {
-          "version": "1.10.0",
-          "from": "verror@1.10.0",
-          "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz"
+          "version": "3.3.2",
+          "from": "uuid@>=3.3.2 <4.0.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz"
         }
       }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.13-BUILD-NUMBER",
+  "version": "6.0.14-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "fh-logger": "0.5.2",
     "fh-mbaas-middleware": "2.3.5",
     "fh-messaging-client": "1.0.5",
-    "fh-metrics-client": "1.0.5",
+    "fh-metrics-client": "1.0.6",
     "fh-service-auth": "1.0.4",
     "mkdirp": "0.5.1",
     "mongodb": "2.2.35",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21698


# What
 Upgrade fh-metrics-client  to 1.0.6 ( minor version bumped )


# Why
- To solve CEVs

# How
* `npm install --save --save-exact fh-metrics-client@1.0.6`

# Verification Steps
Check if the CI will finish with success it did not have breakchanges

## Checklist:
- [X] Code has been tested locally by PR requester
- [ ] Changes have been successfully verified by another team member 
