### PR TITLE
RHMAP-21686 : Upgrade the fh-config lib to the latest version 2.0.0 - performing changes to fix the code

### DIFF
--- a/fh-mbaas.js
+++ b/fh-mbaas.js
@@ -352,7 +352,7 @@ function setupFhconfigReloadHandler(fhconfig) {
     return;
   }
   process.on(fhconfig.RELOAD_CONFIG_SIGNAL, function() {
-    fhconfig.reload(cluster.workers, function(err) {
+    fhconfig.reloadRawConfig(function(err) {
       if (err) {
         /* eslint-disable no-console */
         console.error("Config not reloaded");

--- a/lib/handlers/app/db.js
+++ b/lib/handlers/app/db.js
@@ -9,7 +9,7 @@ exports.getConnectionString = function(req, res, next) {
     if (! appModel || ! appModel.dbConf) {
       return next({"code":404, "message": "no db conf for app"});
     }
-    fhconfig.reload([], function reloaded(err) {
+    fhconfig.reloadRawConfig(function reloaded(err) {
       if (err) {
         return next(err);
       }

--- a/lib/middleware/forms.js
+++ b/lib/middleware/forms.js
@@ -8,7 +8,7 @@ function fixFormDbUrl(req, res, next) {
         return next();
     }
 
-    fhconfig.reload([], function reloaded(err) {
+    fhconfig.reloadRawConfig(function reloaded(err) {
         if (err) {
             return next(err);
         }

--- a/licenses/ASYNC_MIT.TXT
+++ b/licenses/ASYNC_MIT.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2010-2017 Caolan McMahon
+Copyright (c) 2010-2014 Caolan McMahon
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/licenses/HOEK_BSD-3-CLAUSE.TXT
+++ b/licenses/HOEK_BSD-3-CLAUSE.TXT
@@ -1,5 +1,4 @@
-Copyright (c) 2011-2016, Project contributors
-Copyright (c) 2011-2014, Walmart
+Copyright (c) 2011-2014, Walmart and other contributors.
 Copyright (c) 2011, Yahoo Inc.
 All rights reserved.
 
@@ -30,3 +29,4 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 The complete list of contributors can be found at: https://github.com/hapijs/hapi/graphs/contributors
 Portions of this project were initially based on the Yahoo! Inc. Postmile project,
 published at https://github.com/yahoo/postmile.
+b.com/yahoo/postmile.

--- a/licenses/LODASH_MIT.TXT
+++ b/licenses/LODASH_MIT.TXT
@@ -1,16 +1,6 @@
-Copyright JS Foundation and other contributors <https://js.foundation/>
-
-Based on Underscore.js, copyright Jeremy Ashkenas,
+Copyright 2012-2013 The Dojo Foundation <http://dojofoundation.org/>
+Based on Underscore.js 1.5.2, copyright 2009-2013 Jeremy Ashkenas,
 DocumentCloud and Investigative Reporters & Editors <http://underscorejs.org/>
-
-This software consists of voluntary contributions made by many
-individuals. For exact contribution history, see the revision history
-available at https://github.com/lodash/lodash
-
-The following license applies to all parts of this software except as
-documented below:
-
-====
 
 Permission is hereby granted, free of charge, to any person obtaining
 a copy of this software and associated documentation files (the
@@ -27,6 +17,9 @@ THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
 EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
 MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.ENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
 WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/licenses/READABLE-STREAM_MIT.TXT
+++ b/licenses/READABLE-STREAM_MIT.TXT
@@ -1,8 +1,4 @@
-Node.js is licensed for use as follows:
-
-"""
-Copyright Node.js contributors. All rights reserved.
-
+Copyright Joyent, Inc. and other Node contributors. All rights reserved.
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to
 deal in the Software without restriction, including without limitation the
@@ -19,6 +15,8 @@ FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
 AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
+IN THE SOFTWARE.
+DEALINGS
 IN THE SOFTWARE.
 """
 

--- a/licenses/STRING_DECODER_MIT.TXT
+++ b/licenses/STRING_DECODER_MIT.TXT
@@ -1,24 +1,24 @@
-Copyright Joyent, Inc. and other Node contributors.
+Node.js is licensed for use as follows:
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to permit
-persons to whom the Software is furnished to do so, subject to the
-following conditions:
+"""
+Copyright Node.js contributors. All rights reserved.
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
-NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
-DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
-OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
-USE OR OTHER DEALINGS IN THE SOFTWARE.
-OR THE USE OR OTHER DEALINGS
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 IN THE SOFTWARE.
 """
 

--- a/licenses/UNDERSCORE_MIT.TXT
+++ b/licenses/UNDERSCORE_MIT.TXT
@@ -1,4 +1,4 @@
-Copyright (c) 2009-2015 Jeremy Ashkenas, DocumentCloud and Investigative
+Copyright (c) 2009-2018 Jeremy Ashkenas, DocumentCloud and Investigative
 Reporters & Editors
 
 Permission is hereby granted, free of charge, to any person

--- a/licenses/licenses.html
+++ b/licenses/licenses.html
@@ -1136,7 +1136,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-config</td>
-<td>1.0.3</td>
+<td>2.0.0</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-CONFIG_APACHE-2.0.TXT>FH-CONFIG_APACHE-2.0.TXT</a></td>
 </tr>
@@ -1185,7 +1185,7 @@
 <tr>
 <td>N/A</td>
 <td>fh-mbaas</td>
-<td>6.0.13-BUILD-NUMBER</td>
+<td>6.0.14-BUILD-NUMBER</td>
 <td>http:&#x2F;&#x2F;www.apache.org&#x2F;licenses&#x2F;LICENSE-2.0</td>
 <td><a href=FH-MBAAS_APACHE-2.0.TXT>FH-MBAAS_APACHE-2.0.TXT</a></td>
 </tr>

--- a/licenses/licenses.xml
+++ b/licenses/licenses.xml
@@ -1,7 +1,7 @@
 <?xml version='1.0'?>
 <licenseSummary>
     <project>fh-mbaas</project>
-    <version>6.0.13-BUILD-NUMBER</version>
+    <version>6.0.14-BUILD-NUMBER</version>
     <license>Apache-2.0</license>
     <dependencies>
         <dependency>
@@ -1600,7 +1600,7 @@
         </dependency>
         <dependency>
             <packageName>fh-config</packageName>
-            <version>1.0.3</version>
+            <version>2.0.0</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>
@@ -1690,7 +1690,7 @@
         </dependency>
         <dependency>
             <packageName>fh-mbaas</packageName>
-            <version>6.0.13-BUILD-NUMBER</version>
+            <version>6.0.14-BUILD-NUMBER</version>
             <licenses>
                 <license>
                     <name>Apache License 2.0</name>

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -719,9 +719,9 @@
       }
     },
     "fh-config": {
-      "version": "1.0.3",
-      "from": "fh-config@1.0.3",
-      "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-1.0.3.tgz",
+      "version": "2.0.0",
+      "from": "fh-config@2.0.0",
+      "resolved": "https://registry.npmjs.org/fh-config/-/fh-config-2.0.0.tgz",
       "dependencies": {
         "async": {
           "version": "0.9.2",

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.14-BUILD-NUMBER",
+  "version": "6.0.15-BUILD-NUMBER",
   "dependencies": {
     "accepts": {
       "version": "1.3.5",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "fh-cls-mongoose": "2.1.1",
     "fh-cluster": "0.3.0",
     "fh-component-metrics": "2.7.0",
-    "fh-config": "1.0.3",
+    "fh-config": "2.0.0",
     "fh-forms": "1.16.10",
     "fh-health": "0.3.3",
     "fh-logger": "0.5.2",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fh-mbaas",
-  "version": "6.0.14-BUILD-NUMBER",
+  "version": "6.0.15-BUILD-NUMBER",
   "description": "",
   "main": "index.js",
   "author": "FeedHenry",


### PR DESCRIPTION
# Jira link(s)
https://issues.jboss.org/browse/RHMAP-21686


# What
- Upgrade the fh-config lib to the latest version 2.0.0
- Replace reload calls for reloadRawConfig which is the new func for it. 

# Why
- Get fix and keep all using the same/latest version of internal components

# Verification Steps
1. Use this image of fh-mbaas in an RHMAP installation (image docker.io/feedhenry/fh-mbaas:6.0.15-e14f8f5)

<img width="1513" alt="screen shot 2018-10-05 at 08 51 06" src="https://user-images.githubusercontent.com/7708031/46522864-da12d500-c87b-11e8-8989-5b4c7d7a11fc.png">

<img width="1408" alt="screen shot 2018-10-05 at 08 53 31" src="https://user-images.githubusercontent.com/7708031/46522973-32e26d80-c87c-11e8-8292-68d2258bd811.png">

2. Create a project 
3. Change it to use the cloud app : https://github.com/feedhenry/testing-cloud-app
4. Deploy it and check if all tests will return success
<img width="950" alt="screen shot 2018-10-05 at 09 10 30" src="https://user-images.githubusercontent.com/7708031/46523717-8d7cc900-c87e-11e8-9c67-6ef90d5cc732.png">

Check here: https://nodejs-testingcloudappdevbxxb-rhmap-rhmap-dev.ocp4.skunkhenry.com/test

## Checklist:

- [x] Code has been tested locally by PR requester
- [x] Changes have been successfully verified by another team member 